### PR TITLE
Fixes wrong error being displayed when invalid file type chosen for CSV tax import

### DIFF
--- a/includes/admin/importers/class-wc-tax-rate-importer.php
+++ b/includes/admin/importers/class-wc-tax-rate-importer.php
@@ -291,7 +291,7 @@ class WC_Tax_Rate_Importer extends WP_Importer {
 	public function greet() {
 
 		echo '<div class="narrow">';
-		echo '<p>' . esc_html__( 'Hi there! Upload a CSV file containing tax rates to import the contents into your shop. Choose a .csv file to upload, then click "Upload file and import".', 'classic-commerce' ) . '</p>';
+		echo '<p>' . esc_html__( 'Upload a CSV file containing tax rates to import the contents into your shop. Choose a .csv file to upload, then click "Upload file and import".', 'classic-commerce' ) . '</p>';
 
 		/* translators: 1: Link to tax rates sample file 2: Closing link. */
 		echo '<p>' . sprintf( esc_html__( 'Your CSV needs to include columns in a specific order. %1$sClick here to download a sample%2$s.', 'classic-commerce' ), '<a href="' . esc_url( WC()->plugin_url() ) . '/sample-data/sample_tax_rates.csv">', '</a>' ) . '</p>';


### PR DESCRIPTION
### Overview
As outlined in #236 and #222  .

When importing tax rates, the wrong error message is displayed when the user has selected an invalid file type (e.g. .png). See https://github.com/ClassicPress-plugins/classic-commerce/issues/236#issuecomment-669091290 for more detail.

---

### Screenshot - before:

![import-tax-before](https://user-images.githubusercontent.com/4199514/89648902-dc02b080-d8b7-11ea-95fc-35fd9cd3edb3.jpg)

![import-tax-error-before](https://user-images.githubusercontent.com/4199514/89648914-e15ffb00-d8b7-11ea-8823-c75b9d34bc98.jpg)

Message expected: "Invalid file type. The importer supports CSV and TXT file formats."

---

### Changes proposed in this Pull Request:

The main change in this PR is to `handle_upload()` in `includes/admin/importers/class-wc-tax-rate-importer.php`. 

Much of the code here has been borrowed from `handle_upload()` in `includes/admin/importers/class-wc-product-csv-importer-controller.php`. 

Also added new function `get_valid_csv_filetypes()`, again borrowed from `class-wc-product-csv-importer-controller.php`.

---

### How to test the changes in this Pull Request:

1. Replace `includes/admin/importers/class-wc-tax-rate-importer.php` with updated version
2. Go to `Commerce -> Settings -> Tax -> Standard rates` (you could also use `Reduced rate rates` or `Zero rate rates`).

![import-csv](https://user-images.githubusercontent.com/4199514/89649542-df4a6c00-d8b8-11ea-9472-2ec5f5cc1729.jpg)

3. Click on **Import CSV**
4. Click on **Browse** and select any non CSV file (e.g. png)

![import-tax-after](https://user-images.githubusercontent.com/4199514/89648976-f472cb00-d8b7-11ea-97db-891f81330ef8.jpg)

5. Click on **Upload file and import**. This should **fail** and display the **correct** error message.

![import-tax-error-after](https://user-images.githubusercontent.com/4199514/89648995-fb014280-d8b7-11ea-958c-c005a6ceab07.jpg)

6. Click on the (new) `Back` link
7. Click on **Browse** and select the `sample-data/sample_tax_rates.csv` file. 

![import-csv-file](https://user-images.githubusercontent.com/4199514/89652899-15d6b580-d8be-11ea-81fc-274360b937e4.jpg)

8. Click on **Upload file and import**. This should **succeed** and display an **Import complete** message.

![import-success](https://user-images.githubusercontent.com/4199514/89651528-fb9bd800-d8bb-11ea-9f2e-d3b8294a9db7.jpg)

---

### Other information:

I've also added a Back button / link for improved UX.

Closes #236  .
