### PR TITLE
Replaces references to ClassicPress-research with ClassicPress-plugins

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -3,9 +3,9 @@
 There are many ways to contribute to the Classic Commerce project!
 
 - Translating strings into your language.
-- Answering questions on GitHub Classic Commerce [Issues Page](https://github.com/ClassicPress-research/classic-commerce/issues).
+- Answering questions on GitHub Classic Commerce [Issues Page](https://github.com/ClassicPress-plugins/classic-commerce/issues).
 - Submitting fixes, improvements and enhancements through PRs.
-- Testing the development builds and [filing issues](https://github.com/ClassicPress-research/classic-commerce/issues)
+- Testing the development builds and [filing issues](https://github.com/ClassicPress-plugins/classic-commerce/issues)
 
 Classic Commerce is still growing and your help making it even more awesome will be greatly appreciated :)
 
@@ -15,23 +15,23 @@ and [send a pull request](https://help.github.com/articles/using-pull-requests/)
 
 ## Feature Requests
 
-Feature requests can be [submitted to our issue tracker](https://github.com/ClassicPress-research/classic-commerce/issues/new?template=Feature_request.md). Be sure to include a description of the expected behavior and use case, and before submitting a request, please search for similar ones in the closed issues.
+Feature requests can be [submitted to our issue tracker](https://github.com/ClassicPress-plugins/classic-commerce/issues/new?template=Feature_request.md). Be sure to include a description of the expected behavior and use case, and before submitting a request, please search for similar ones in the closed issues.
 
 Feature request issues will remain closed until we see sufficient interest via comments and [👍 reactions](https://help.github.com/articles/about-discussions-in-issues-and-pull-requests/) from the community.
 
-You can see a [list of current feature requests which require votes here](https://github.com/ClassicPress-research/classic-commerce/issues?q=label%3A%22votes+needed%22+label%3Aenhancement+sort%3Areactions-%2B1-desc+is%3Aclosed).
+You can see a [list of current feature requests which require votes here](https://github.com/ClassicPress-plugins/classic-commerce/issues?q=label%3A%22votes+needed%22+label%3Aenhancement+sort%3Areactions-%2B1-desc+is%3Aclosed).
 
 ## Technical Support / Questions
 
 We currently offer technical support on GitHub so we recommend using the following:
 
 **Technical support, General usage and development questions**
-If you have a problem, you may want to write an issue to the Classic Commerce GitHub Repo: https://github.com/ClassicPress-research/classic-commerce/issues
+If you have a problem, you may want to write an issue to the Classic Commerce GitHub Repo: https://github.com/ClassicPress-plugins/classic-commerce/issues
 
 ## Submit a PR
 
 Start by cloning this repo into your staging site plugins folder via the terminal or command prompt using:
-- Run `git clone https://github.com/ClassicPress-research/classic-commerce`
+- Run `git clone https://github.com/ClassicPress-plugins/classic-commerce`
 - Run `cd classic-commerce`
 - Run `composer install`
 - Run `npm install`

--- a/.github/ISSUE_TEMPLATE/Support.md
+++ b/.github/ISSUE_TEMPLATE/Support.md
@@ -10,4 +10,4 @@ We don't offer technical support on GitHub so we recommend using the following:
 Usage docs can be found here: https://docs.woocommerce.com/
 
 **Technical support, General usage and development questions**
-If you have a problem, you may want to write an issue to the Classic Commerce GitHub Repo: https://github.com/ClassicPress-research/classic-commerce/issues
+If you have a problem, you may want to write an issue to the Classic Commerce GitHub Repo: https://github.com/ClassicPress-plugins/classic-commerce/issues

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ### All Submissions:
 
-* [ ] Have you followed the [Classic Commerce Contributing guideline](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
+* [ ] Have you followed the [Classic Commerce Contributing guideline](https://github.com/ClassicPress-plugins/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
 * [ ] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
 * [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -34,4 +34,4 @@ First alpha release of Classic Commerce
 WIP - Forking and documenting Classic Commerce 0.1.0
 
 = WooCommerce 3.4.5 - 2018-08-29 =
-[See changelog archive for all versions](https://raw.githubusercontent.com/ClassicPress-research/classic-commerce/master/CHANGELOG-Archive.txt).
+[See changelog archive for all versions](https://raw.githubusercontent.com/ClassicPress-plugins/classic-commerce/master/CHANGELOG-Archive.txt).

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -184,7 +184,7 @@ module.exports = function( grunt ) {
 				type: 'wp-plugin',
 				domainPath: 'i18n/languages',
 				potHeaders: {
-					'report-msgid-bugs-to': 'https://github.com/ClassicPress-Research/classic-commerce/issues',
+					'report-msgid-bugs-to': 'https://github.com/ClassicPress-plugins/classic-commerce/issues',
 					'language-team': 'LANGUAGE <EMAIL@ADDRESS>'
 				}
 			},

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Classic Commerce [![Build Status](https://travis-ci.com/ClassicPress-research/classic-commerce.svg?branch=master)](https://travis-ci.com/ClassicPress-research/classic-commerce)
+# Classic Commerce [![Build Status](https://travis-ci.com/ClassicPress-plugins/classic-commerce.svg?branch=master)](https://travis-ci.com/ClassicPress-plugins/classic-commerce)
 
 Welcome to the Classic Commerce repository on GitHub. This is a fork of WooCommerce and is still in development.
 
@@ -6,10 +6,10 @@ Classic Commerce is a simple, powerful and independent e-commerce platform. Sell
 
 You can browse the source, look at open issues and keep track of development here.
 
-We recommend all developers follow the [Issues](https://github.com/ClassicPress-research/classic-commerce/issues) and [Pull Requests](https://github.com/ClassicPress-research/classic-commerce/pulls) for the latest development updates.
+We recommend all developers follow the [Issues](https://github.com/ClassicPress-plugins/classic-commerce/issues) and [Pull Requests](https://github.com/ClassicPress-plugins/classic-commerce/pulls) for the latest development updates.
 
 ## Roadmap
-You can follow up on the development cycle by reading our [roadmap](https://github.com/ClassicPress-research/classic-commerce/wiki/Plugin-Roadmap).
+You can follow up on the development cycle by reading our [roadmap](https://github.com/ClassicPress-plugins/classic-commerce/wiki/Plugin-Roadmap).
 
 ## FAQs
 **Can I install WooCommerce together with Classic Commerce?**
@@ -42,5 +42,5 @@ To disclose a security issue to our team. (security@classicpress.net)
 This repository is most suitable for development but can also be used for support. We will add a support tag to your issue. However, this might take a little longer to get a response. You can also use the dedicated support area on the [ClassicPress community forum](https://forums.classicpress.net/tags/classic-commerce/).
 
 ## Contributing to Classic Commerce
-If you have a patch or have stumbled upon an issue with Classic Commerce core, you can contribute this back to the code. Please read our [contributor guidelines](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md) for more information about how you can do this.
+If you have a patch or have stumbled upon an issue with Classic Commerce core, you can contribute this back to the code. Please read our [contributor guidelines](https://github.com/ClassicPress-plugins/classic-commerce/blob/master/.github/CONTRIBUTING.md) for more information about how you can do this.
 

--- a/classic-commerce.php
+++ b/classic-commerce.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * Plugin Name: Classic Commerce
- * Plugin URI: https://github.com/ClassicPress-research/classic-commerce
+ * Plugin URI: https://github.com/ClassicPress-plugins/classic-commerce
  * Description: A simple, powerful and independent e-commerce platform. Sell anything with ease.
  * Version: 1.0.0-beta.1
  * Author: ClassicPress Research Team
- * Author URI: https://github.com/ClassicPress-research/classic-commerce
+ * Author URI: https://github.com/ClassicPress-plugins/classic-commerce
  * Text Domain: classic-commerce
  * Domain Path: /i18n/languages/
  *

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-  "name": "classicpress-research/classic-commerce",
+  "name": "classicpress-plugins/classic-commerce",
   "description": "A simple, powerful and independent e-commerce platform. Sell anything with ease.",
-  "homepage": "https://github.com/ClassicPress-research/classic-commerce",
+  "homepage": "https://github.com/ClassicPress-plugins/classic-commerce",
   "type": "wordpress-plugin",
   "license": "GPL-3.0-or-later",
   "prefer-stable": true,

--- a/i18n/languages/classic-commerce.pot
+++ b/i18n/languages/classic-commerce.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Classic Commerce 0.1.0\n"
 "Report-Msgid-Bugs-To: "
-"https://github.com/ClassicPress-Research/classic-commerce/issues\n"
+"https://github.com/ClassicPress-plugins/classic-commerce/issues\n"
 "POT-Creation-Date: 2019-11-11 19:19:17+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -26462,7 +26462,7 @@ msgid "Only logged in customers who have purchased this product may leave a revi
 msgstr ""
 
 #. Author URI of the plugin/theme
-msgid "https://github.com/ClassicPress-research/classic-commerce"
+msgid "https://github.com/ClassicPress-plugins/classic-commerce"
 msgstr ""
 
 #. Description of the plugin/theme

--- a/includes/admin/class-wc-admin-help.php
+++ b/includes/admin/class-wc-admin-help.php
@@ -64,8 +64,8 @@ class WC_Admin_Help {
 				'content' =>
 					'<h2>' . __( 'Found a bug?', 'classic-commerce' ) . '</h2>' .
 					/* translators: 1: GitHub issues URL 2: System status report URL */
-					'<p>' . sprintf( __( 'If you find a bug within Classic Commerce core you can create a ticket via <a href="%1$s">Github issues</a>. To help us solve your issue, please be as descriptive as possible and include your <a href="%2$s">system status report</a>.', 'classic-commerce' ), 'https://github.com/ClassicPress-research/classic-commerce/issues', admin_url( 'admin.php?page=wc-status' ) ) . '</p>' .
-					'<p><a href="https://github.com/ClassicPress-research/classic-commerce/issues" class="button button-primary">' . __( 'Report a bug', 'classic-commerce' ) . '</a> <a href="' . admin_url( 'admin.php?page=wc-status' ) . '" class="button">' . __( 'System status', 'classic-commerce' ) . '</a></p>',
+					'<p>' . sprintf( __( 'If you find a bug within Classic Commerce core you can create a ticket via <a href="%1$s">Github issues</a>. To help us solve your issue, please be as descriptive as possible and include your <a href="%2$s">system status report</a>.', 'classic-commerce' ), 'https://github.com/ClassicPress-plugins/classic-commerce/issues', admin_url( 'admin.php?page=wc-status' ) ) . '</p>' .
+					'<p><a href="https://github.com/ClassicPress-plugins/classic-commerce/issues" class="button button-primary">' . __( 'Report a bug', 'classic-commerce' ) . '</a> <a href="' . admin_url( 'admin.php?page=wc-status' ) . '" class="button">' . __( 'System status', 'classic-commerce' ) . '</a></p>',
 			)
 		);
 
@@ -82,7 +82,7 @@ class WC_Admin_Help {
 
 		$screen->set_help_sidebar(
 			'<p><strong>' . __( 'For more information:', 'classic-commerce' ) . '</strong></p>' .
-			'<p><a href="https://github.com/ClassicPress-research/classic-commerce/" target="_blank">' . __( 'Github project', 'classic-commerce' ) . '</a></p>' .
+			'<p><a href="https://github.com/ClassicPress-plugins/classic-commerce/" target="_blank">' . __( 'Github project', 'classic-commerce' ) . '</a></p>' .
 			'<p><a href="https://classicpress.net/" target="_blank">' . __( 'About ClassicPress', 'classic-commerce' ) . '</a></p>' .
 			'<p><a href="https://woocommerce.com/product-category/woocommerce-extensions/" target="_blank">' . __( 'Extensions', 'classic-commerce' ) . '</a></p>'
 		);

--- a/includes/admin/class-wc-admin-menus.php
+++ b/includes/admin/class-wc-admin-menus.php
@@ -140,7 +140,7 @@ class WC_Admin_Menus {
 	 *
 	 * - https://www.skyverge.com/blog/screen-id-checks-wordpress-submenu-pages/
 	 * - https://wpdirectory.net, search for "sanitize_title.{0,90}woocommerce"
-	 * - https://github.com/ClassicPress-research/classic-commerce/pull/119
+	 * - https://github.com/ClassicPress-plugins/classic-commerce/pull/119
 	 *
 	 * Based on https://gist.github.com/geoffspink/e191a7cad8c9a23f5c60.
 	 *

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -267,7 +267,7 @@ class WC_Admin_Setup_Wizard {
 			<?php do_action( 'admin_head' ); ?>
 		</head>
 		<body class="wc-setup wp-core-ui">
-			<h1 id="wc-logo"><a href="https://github.com/ClassicPress-research/classic-commerce/"><img src="<?php echo esc_url( WC()->plugin_url() ); ?>/assets/images/classic-commerce-logo.png" alt="Classic Commerce" /></a></h1>
+			<h1 id="wc-logo"><a href="https://github.com/ClassicPress-plugins/classic-commerce/"><img src="<?php echo esc_url( WC()->plugin_url() ); ?>/assets/images/classic-commerce-logo.png" alt="Classic Commerce" /></a></h1>
 		<?php
 	}
 

--- a/includes/admin/settings/class-wc-settings-emails.php
+++ b/includes/admin/settings/class-wc-settings-emails.php
@@ -133,7 +133,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 					'css'         => 'width:300px; height: 75px;',
 					'placeholder' => __( 'N/A', 'classic-commerce' ),
 					'type'        => 'textarea',
-					'default'     => '{site_title}<br/>Powered by <a href="https://github.com/ClassicPress-research/classic-commerce/">Classic Commerce</a>',
+					'default'     => '{site_title}<br/>Powered by <a href="https://github.com/ClassicPress-plugins/classic-commerce/">Classic Commerce</a>',
 					'autoload'    => false,
 					'desc_tip'    => true,
 				),

--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -62,7 +62,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 	<p><?php printf( __( 'For discussion and help with finding compatible Classic Commerce addons, use the <a href="%s">ClassicPress community forum</a>.', 'classic-commerce' ), 'https://forums.classicpress.net/tags/classic-commerce/' ); ?></p>
 
-	<p><?php printf( __( 'For problems with the Classic Commerce core files please raise an issue via <a href="%s">Github issues</a>.', 'classic-commerce' ), 'https://github.com/ClassicPress-research/classic-commerce/issues/' ); ?></p>
+	<p><?php printf( __( 'For problems with the Classic Commerce core files please raise an issue via <a href="%s">Github issues</a>.', 'classic-commerce' ), 'https://github.com/ClassicPress-plugins/classic-commerce/issues/' ); ?></p>
 
 	<hr />
 

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -1196,7 +1196,7 @@ CREATE TABLE {$wpdb->prefix}woocommerce_termmeta (
 			$row_meta = array(
 				'docs'    => '<a href="' . esc_url( apply_filters( 'woocommerce_docs_url', 'https://docs.woocommerce.com/documentation/plugins/woocommerce/' ) ) . '" aria-label="' . esc_attr__( 'View WooCommerce documentation', 'classic-commerce' ) . '" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Docs', 'classic-commerce' ) . '</a>',
 				'apidocs' => '<a href="' . esc_url( apply_filters( 'woocommerce_apidocs_url', 'https://docs.woocommerce.com/wc-apidocs/' ) ) . '" aria-label="' . esc_attr__( 'View WooCommerce API docs', 'classic-commerce' ) . '" target="_blank" rel="noopener noreferrer">' . esc_html__( 'API docs', 'classic-commerce' ) . '</a>',
-				'support' => '<a href="' . esc_url( apply_filters( 'woocommerce_support_url', 'https://github.com/ClassicPress-research/classic-commerce/issues' ) ) . '" aria-label="' . esc_attr__( 'Visit issues  support section on github', 'classic-commerce' ) . '" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Support', 'classic-commerce' ) . '</a>',
+				'support' => '<a href="' . esc_url( apply_filters( 'woocommerce_support_url', 'https://github.com/ClassicPress-plugins/classic-commerce/issues' ) ) . '" aria-label="' . esc_attr__( 'Visit issues  support section on github', 'classic-commerce' ) . '" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Support', 'classic-commerce' ) . '</a>',
 			);
 
 			return array_merge( $links, $row_meta );

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "classic-commerce",
   "title": "Classic Commerce",
   "version": "0.1.0",
-  "homepage": "https://github.com/ClassicPress-research/classic-commerce",
+  "homepage": "https://github.com/ClassicPress-plugins/classic-commerce",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ClassicPress-research/classic-commerce.git"
+    "url": "https://github.com/ClassicPress-plugins/classic-commerce.git"
   },
   "license": "GPL-3.0+",
   "main": "Gruntfile.js",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Classic Commerce Contributing guideline](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

CC was moved to ClassicPress-plugins from ClassicPress-research on July 14 2020.

This PR replaces all references to ClassicPress-research with ClassicPress-plugins.

Closes #248 .
