### PR TITLE
Hide stock levels on dashboard widget if inventory disabled

### DIFF
--- a/includes/admin/class-wc-admin-dashboard.php
+++ b/includes/admin/class-wc-admin-dashboard.php
@@ -239,6 +239,8 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 				set_transient( $transient_name, $outofstock_count, DAY_IN_SECONDS * 30 );
 			}
 			?>
+			
+			<?php if ( 'yes' === get_option( 'woocommerce_manage_stock' ) ) { ?>
 			<li class="low-in-stock">
 			<a href="<?php echo admin_url( 'admin.php?page=wc-reports&tab=stock&report=low_in_stock' ); ?>">
 				<?php
@@ -261,6 +263,8 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 				?>
 				</a>
 			</li>
+			<?php } ?>
+			
 			<?php
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Classic Commerce Contributing guideline](https://github.com/ClassicPress-plugins/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Hide stock levels in dashboard widget when inventory disabled. #260

Closes #260  .

### How to test the changes in this Pull Request:

1. Disable `Enable stock management` setting
2. Backup `includes/admin/class-wc-admin-dashboard.php`
3. Replace file with updated version
4. View widget in dashboard. Stock should be hidden.

![cc-stock-hidden](https://user-images.githubusercontent.com/4199514/92320667-2001e600-f01b-11ea-8e63-ea30bb1c3118.jpg)

5. Enable `Enable stock management` setting
6. View widget in dashboard. Stock should be visible.

![cc-stock-visible](https://user-images.githubusercontent.com/4199514/92320697-44f65900-f01b-11ea-96f4-9d9d5a152554.jpg)

7. Restore backup copy of `includes/admin/class-wc-admin-dashboard.php`