### PR TITLE
Change system report docs url

### DIFF
--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -31,7 +31,7 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 	</p>
 	<p class="submit">
 		<a href="#" class="button-primary debug-report"><?php esc_html_e( 'Get system report', 'classic-commerce' ); ?></a>
-		<a class="button-secondary docs" href="https://docs.woocommerce.com/document/understanding-the-woocommerce-system-status-report/" target="_blank">
+		<a class="button-secondary docs" href="https://classiccommerce.cc/docs/installation-and-setup/status-report/" target="_blank">
 			<?php esc_html_e( 'Understanding the status report', 'classic-commerce' ); ?>
 		</a>
 	</p>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Classic Commerce Contributing guideline](https://github.com/ClassicPress-plugins/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Change the URL on the "Understanding the Status Report" button to point to new page on CC website docs.

### How to test the changes in this Pull Request:

1. Copy revised file html-admin-page-status-report.php into test site
2. Visit the status report area on the site
3. Click the button
4. Go to CC site!

### Other information:

The Woo doc page is now very different to our version and is not very useful.

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you included screenshots before/after your changes, if applicable?

