### PR TITLE
Change remaining Woo doc links to CC

### DIFF
--- a/includes/admin/class-wc-admin-help.php
+++ b/includes/admin/class-wc-admin-help.php
@@ -44,8 +44,8 @@ class WC_Admin_Help {
 					'<h2>' . __( 'Help &amp; Support', 'classic-commerce' ) . '</h2>' .
 					'<p>' . sprintf(
 						/* translators: %s: Documentation URL */
-						__( 'Should you need help understanding, using, or extending Classic Commerce, <a href="%s">please refer to the WooCommerce documentation</a>. You will find all kinds of resources including snippets, tutorials and much more.', 'classic-commerce' ),
-						'https://docs.woocommerce.com/documentation/plugins/woocommerce/'
+						__( 'Should you need help understanding, using, or extending Classic Commerce, <a href="%s">please refer to the documentation</a>. You will find all kinds of resources including snippets, tutorials and much more.', 'classic-commerce' ),
+						'https://classiccommerce.cc/docs/'
 					) . '</p>' .
 					'<p>' . sprintf(
 						/* translators: %s: Forum URL */

--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -847,7 +847,7 @@ class WC_Admin_Post_Types {
 		if ( $post && absint( $post->ID ) === $shop_page_id ) {
 			echo '<div class="notice notice-info">';
 			/* translators: %s: URL to read more about the shop page. */
-			echo '<p>' . sprintf( wp_kses_post( __( 'This is the Classic Commerce shop page. The shop page is a special archive that lists your products. <a href="%s">You can read more about this here</a>.', 'classic-commerce' ) ), 'https://docs.woocommerce.com/document/woocommerce-pages/#section-4' ) . '</p>';
+			echo '<p>' . sprintf( wp_kses_post( __( 'This is the Classic Commerce shop page. The shop page is a special archive that lists your products. <a href="%s">You can read more about this here</a>.', 'classic-commerce' ) ), 'https://classiccommerce.cc/docs/installation-and-setup/classic-commerce-pages/' ) . '</p>';
 			echo '</div>';
 		}
 	}

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -1220,13 +1220,10 @@ class WC_Admin_Setup_Wizard {
 	public function wc_setup_ready() {
 		// We've made it! Don't prompt the user to run the wizard again.
 		WC_Admin_Notices::remove_notice( 'install' );
-
-		$videos_url   = 'https://docs.woocommerce.com/document/woocommerce-guided-tour-videos/';
-		$docs_url     = 'https://docs.woocommerce.com/documentation/plugins/woocommerce/getting-started/';
+		$docs_url     = 'https://classiccommerce.cc/docs/installation-and-setup/';
 		$help_text    = sprintf(
-			/* translators: %1$s: link to videos, %2$s: link to docs */
-			__( 'Watch <a href="%1$s" target="_blank">guided tour videos</a> to learn more about Classic Commerce, or visit WooCommerce.com to learn more about <a href="%2$s" target="_blank">getting started</a>.', 'classic-commerce' ),
-			$videos_url,
+			/* translators: %1$s: link to docs */
+			__( 'Visit classiccommerce.cc to learn more about <a href="%1$s" target="_blank">getting started</a>.', 'classic-commerce' ),
 			$docs_url
 		);
 		?>

--- a/includes/admin/list-tables/class-wc-admin-list-table-coupons.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-coupons.php
@@ -45,7 +45,7 @@ class WC_Admin_List_Table_Coupons extends WC_Admin_List_Table {
 		echo '<div class="woocommerce-BlankState">';
 		echo '<h2 class="woocommerce-BlankState-message">' . esc_html__( 'Coupons are a great way to offer discounts and rewards to your customers. They will appear here once created.', 'classic-commerce' ) . '</h2>';
 		echo '<a class="woocommerce-BlankState-cta button-primary button" href="' . esc_url( admin_url( 'post-new.php?post_type=shop_coupon' ) ) . '">' . esc_html__( 'Create your first coupon', 'classic-commerce' ) . '</a>';
-		echo '<a class="woocommerce-BlankState-cta button" target="_blank" href="https://docs.woocommerce.com/document/coupon-management/">' . esc_html__( 'Learn more about coupons', 'classic-commerce' ) . '</a>';
+		echo '<a class="woocommerce-BlankState-cta button" target="_blank" href="https://classiccommerce.cc/docs/installation-and-setup/coupons/">' . esc_html__( 'Learn more about coupons', 'classic-commerce' ) . '</a>';
 		echo '</div>';
 	}
 

--- a/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -48,7 +48,7 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 	protected function render_blank_state() {
 		echo '<div class="woocommerce-BlankState">';
 		echo '<h2 class="woocommerce-BlankState-message">' . esc_html__( 'When you receive a new order, it will appear here.', 'classic-commerce' ) . '</h2>';
-		echo '<a class="woocommerce-BlankState-cta button-primary button" target="_blank" href="https://docs.woocommerce.com/document/managing-orders/">' . esc_html__( 'Learn more about orders', 'classic-commerce' ) . '</a>';
+		echo '<a class="woocommerce-BlankState-cta button-primary button" target="_blank" href="https://classiccommerce.cc/usage-and-maintenance/managing-orders/">' . esc_html__( 'Learn more about orders', 'classic-commerce' ) . '</a>';
 		echo '</div>';
 	}
 

--- a/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
@@ -102,7 +102,7 @@ class WC_Meta_Box_Coupon_Data {
 						array(
 							'id'          => 'free_shipping',
 							'label'       => __( 'Allow free shipping', 'classic-commerce' ),
-							'description' => sprintf( __( 'Check this box if the coupon grants free shipping. A <a href="%s" target="_blank">free shipping method</a> must be enabled in your shipping zone and be set to require "a valid free shipping coupon" (see the "Free Shipping Requires" setting).', 'classic-commerce' ), 'https://docs.woocommerce.com/document/free-shipping/' ),
+							'description' => sprintf( __( 'Check this box if the coupon grants free shipping. A <a href="%s" target="_blank">free shipping method</a> must be enabled in your shipping zone and be set to require "a valid free shipping coupon" (see the "Free Shipping Requires" setting).', 'classic-commerce' ), 'https://classiccommerce.cc/docs/installation-and-setup/shipping/' ),
 							'value'       => wc_bool_to_string( $coupon->get_free_shipping( 'edit' ) ),
 						)
 					);

--- a/includes/admin/meta-boxes/views/html-product-data-variations.php
+++ b/includes/admin/meta-boxes/views/html-product-data-variations.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 			<div id="message" class="inline notice woocommerce-message">
 				<p><?php echo wp_kses_post( __( 'Before you can add a variation you need to add some variation attributes on the <strong>Attributes</strong> tab.', 'classic-commerce' ) ); ?></p>
-				<p><a class="button-primary" href="<?php echo esc_url( apply_filters( 'woocommerce_docs_url', 'https://docs.woocommerce.com/document/variable-product/', 'product-variations' ) ); ?>" target="_blank"><?php esc_html_e( 'Learn more', 'classic-commerce' ); ?></a></p>
+				<p><a class="button-primary" href="<?php echo esc_url( apply_filters( 'woocommerce_docs_url', 'https://classiccommerce.cc/docs/installation-and-setup/variable-products/', 'product-variations' ) ); ?>" target="_blank"><?php esc_html_e( 'Learn more', 'classic-commerce' ); ?></a></p>
 			</div>
 
 		<?php else : ?>

--- a/includes/admin/settings/class-wc-settings-advanced.php
+++ b/includes/admin/settings/class-wc-settings-advanced.php
@@ -135,7 +135,7 @@ class WC_Settings_Advanced extends WC_Settings_Page {
 						'checkboxgroup'   => 'start',
 						'show_if_checked' => 'option',
 						/* Translators: %s Docs URL. */
-						'desc_tip'        => sprintf( __( 'Force SSL (HTTPS) on the checkout pages (<a href="%s" target="_blank">an SSL Certificate is required</a>).', 'classic-commerce' ), 'https://docs.woocommerce.com/document/ssl-and-https/#section-3' ),
+						'desc_tip'        => sprintf( __( 'Force SSL (HTTPS) on the checkout pages (<a href="%s" target="_blank">an SSL Certificate is required</a>).', 'classic-commerce' ), 'https://classiccommerce.cc/docs/installation-and-setup/ssl-and-https/' ),
 					),
 
 					'unforce_ssl_checkout' => array(

--- a/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
+++ b/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
@@ -64,7 +64,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					<div class="wc-shipping-zone-postcodes">
 						<textarea name="zone_postcodes" data-attribute="zone_postcodes" id="zone_postcodes" placeholder="<?php esc_attr_e( 'List 1 postcode per line', 'classic-commerce' ); ?>" class="input-text large-text" cols="25" rows="5"><?php echo esc_textarea( implode( "\n", $postcodes ) ); ?></textarea>
 						<?php /* translators: Classic Commerce link to setting up shipping zones */ ?>
-						<span class="description"><?php printf( __( 'Postcodes containing wildcards (e.g. CB23*) or fully numeric ranges (e.g. <code>90210...99000</code>) are also supported. Please see the shipping zones <a href="%s" target="_blank">documentation</a>) for more information.', 'classic-commerce' ), 'https://docs.woocommerce.com/document/setting-up-shipping-zones/#section-3' ); ?></span><?php // @codingStandardsIgnoreLine. ?>
+						<span class="description"><?php printf( __( 'Postcodes containing wildcards (e.g. CB23*) or fully numeric ranges (e.g. <code>90210...99000</code>) are also supported. Please see the shipping zones <a href="%s" target="_blank">documentation</a>) for more information.', 'classic-commerce' ), 'https://classiccommerce.cc/docs/installation-and-setup/shipping/' ); ?></span><?php // @codingStandardsIgnoreLine. ?>
 					</div>
 				</td>
 			<?php endif; ?>

--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -220,7 +220,7 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 				if ( version_compare( $environment['php_version'], '7.2', '>=' ) ) {
 					echo '<mark class="yes">' . esc_html( $environment['php_version'] ) . '</mark>';
 				} else {
-					$update_link = ' <a href="https://docs.woocommerce.com/document/how-to-update-your-php-version/" target="_blank">' . esc_html__( 'How to update your PHP version', 'classic-commerce' ) . '</a>';
+					$update_link = ' <a href="https://classiccommerce.cc/usage-and-maintenance/update-php-version/" target="_blank">' . esc_html__( 'How to update your PHP version', 'classic-commerce' ) . '</a>';
 					$class       = 'error';
 
 					if ( version_compare( $environment['php_version'], '5.4', '<' ) ) {
@@ -444,7 +444,7 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 				<?php
 				if ( strlen( $database['database_prefix'] ) > 20 ) {
 					/* Translators: %1$s: Database prefix, %2$s: Docs link. */
-					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( esc_html__( '%1$s - We recommend using a prefix with less than 20 characters. See: %2$s', 'classic-commerce' ), esc_html( $database['database_prefix'] ), '<a href="https://docs.woocommerce.com/document/completed-order-email-doesnt-contain-download-links/#section-2" target="_blank">' . esc_html__( 'How to update your database table prefix', 'classic-commerce' ) . '</a>' ) . '</mark>';
+					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( esc_html__( '%1$s - We recommend using a prefix with less than 20 characters. See: %2$s', 'classic-commerce' ), esc_html( $database['database_prefix'] ), '<a href="https://classiccommerce.cc/usage-and-maintenance/update-database-table-prefix/" target="_blank">' . esc_html__( 'How to update your database table prefix', 'classic-commerce' ) . '</a>' ) . '</mark>';
 				} else {
 					echo '<mark class="yes">' . esc_html( $database['database_prefix'] ) . '</mark>';
 				}
@@ -557,7 +557,7 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 					<mark class="error"><span class="dashicons dashicons-warning"></span>
 					<?php
 					/* Translators: %s: docs link. */
-					echo wp_kses_post( sprintf( __( 'Your store is not using HTTPS. <a href="%s" target="_blank">Learn more about HTTPS and SSL Certificates</a>.', 'classic-commerce' ), 'https://docs.woocommerce.com/document/ssl-and-https/' ) );
+					echo wp_kses_post( sprintf( __( 'Your store is not using HTTPS. <a href="%s" target="_blank">Learn more about HTTPS and SSL Certificates</a>.', 'classic-commerce' ), 'https://classiccommerce.cc/docs/installation-and-setup/ssl-and-https/' ) );
 					?>
 					</mark>
 				<?php endif; ?>
@@ -894,7 +894,7 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 					<mark class="error">
 						<span class="dashicons dashicons-warning"></span>
 					</mark>
-					<a href="https://docs.woocommerce.com/document/fix-outdated-templates-woocommerce/" target="_blank">
+					<a href="https://classiccommerce.cc/usage-and-maintenance/fix-outdated-templates/" target="_blank">
 						<?php esc_html_e( 'Learn how to update', 'classic-commerce' ); ?>
 					</a>
 				</td>

--- a/includes/admin/views/html-notice-legacy-shipping.php
+++ b/includes/admin/views/html-notice-legacy-shipping.php
@@ -17,6 +17,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<?php if ( empty( $_GET['page'] ) || empty( $_GET['tab'] ) || 'wc-settings' !== $_GET['page'] || 'shipping' !== $_GET['tab'] ) : ?>
 			<a class="button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=wc-settings&tab=shipping' ) ); ?>"><?php _e( 'Setup shipping zones', 'classic-commerce' ); ?></a>
 		<?php endif; ?>
-		<a class="button-secondary" href="https://docs.woocommerce.com/document/setting-up-shipping-zones/"><?php _e( 'Learn more about shipping zones', 'classic-commerce' ); ?></a>
+		<a class="button-secondary" href="https://classiccommerce.cc/docs/installation-and-setup/shipping/"><?php _e( 'Learn more about shipping zones', 'classic-commerce' ); ?></a>
 	</p>
 </div>

--- a/includes/admin/views/html-notice-no-shipping-methods.php
+++ b/includes/admin/views/html-notice-no-shipping-methods.php
@@ -16,6 +16,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 	<p class="submit">
 		<a class="button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=wc-settings&tab=shipping' ) ); ?>"><?php _e( 'Setup shipping zones', 'classic-commerce' ); ?></a>
-		<a class="button-secondary" href="https://docs.woocommerce.com/document/setting-up-shipping-zones/"><?php _e( 'Learn more about shipping zones', 'classic-commerce' ); ?></a>
+		<a class="button-secondary" href="https://classiccommerce.cc/docs/installation-and-setup/shipping/"><?php _e( 'Learn more about shipping zones', 'classic-commerce' ); ?></a>
 	</p>
 </div>

--- a/includes/admin/views/html-notice-secure-connection.php
+++ b/includes/admin/views/html-notice-secure-connection.php
@@ -16,7 +16,7 @@ defined( 'ABSPATH' ) || exit;
 		echo wp_kses_post( sprintf(
 			/* translators: %s: documentation URL */
 			__( 'Your store does not appear to be using a secure connection. We highly recommend serving your entire website over an HTTPS connection to help keep customer data secure. <a href="%s">Learn more here.</a>', 'classic-commerce' ),
-			'https://docs.woocommerce.com/document/ssl-and-https/'
+			'https://classiccommerce.cc/docs/installation-and-setup/ssl-and-https/'
 		) );
 	?>
 	</p>

--- a/includes/admin/views/html-notice-template-check.php
+++ b/includes/admin/views/html-notice-template-check.php
@@ -23,7 +23,7 @@ $theme = wp_get_theme();
 		</ol>
 	</p>
 	<p class="submit">
-		<a class="button-primary" href="https://docs.woocommerce.com/document/template-structure/" target="_blank"><?php esc_html_e( 'Learn more about templates', 'classic-commerce' ); ?></a>
+		<a class="button-primary" href="https://classiccommerce.cc/docs/installation-and-setup/template-structure/" target="_blank"><?php esc_html_e( 'Learn more about templates', 'classic-commerce' ); ?></a>
 		<a class="button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=wc-status' ) ); ?>" target="_blank"><?php esc_html_e( 'View affected templates', 'classic-commerce' ); ?></a>
 	</p>
 </div>

--- a/includes/admin/views/html-notice-theme-support.php
+++ b/includes/admin/views/html-notice-theme-support.php
@@ -11,8 +11,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 <div id="message" class="updated woocommerce-message wc-connect">
 	<a class="woocommerce-message-close notice-dismiss" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wc-hide-notice', 'theme_support' ), 'woocommerce_hide_notices_nonce', '_wc_notice_nonce' ) ); ?>"><?php _e( 'Dismiss', 'classic-commerce' ); ?></a>
 
-	<p><?php printf( __( '<strong>Your theme does not declare Classic Commerce support</strong> &#8211; Please read our <a href="%1s" target="_blank">integration</a>.', 'classic-commerce' ), esc_url( apply_filters( 'woocommerce_docs_url', 'https://docs.woocommerce.com/document/third-party-custom-theme-compatibility/', 'theme-compatibility' ) ) ); ?></p>
+	<p><?php printf( __( '<strong>Your theme does not declare Classic Commerce support</strong> &#8211; Please read our <a href="%1s" target="_blank">integration</a>.', 'classic-commerce' ), esc_url( apply_filters( 'woocommerce_docs_url', 'https://classiccommerce.cc/docs/installation-and-setup/theme-compatibility/', 'theme-compatibility' ) ) ); ?></p>
 	<p class="submit">
-		<a href="<?php echo esc_url( apply_filters( 'woocommerce_docs_url', 'http://docs.woocommerce.com/document/third-party-custom-theme-compatibility/' ) ); ?>" class="button-secondary" target="_blank"><?php _e( 'Theme integration guide', 'classic-commerce' ); ?></a>
+		<a href="<?php echo esc_url( apply_filters( 'woocommerce_docs_url', 'https://classiccommerce.cc/docs/installation-and-setup/theme-compatibility/' ) ); ?>" class="button-secondary" target="_blank"><?php _e( 'Theme integration guide', 'classic-commerce' ); ?></a>
 	</p>
 </div>

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -1194,7 +1194,7 @@ CREATE TABLE {$wpdb->prefix}woocommerce_termmeta (
 	public static function plugin_row_meta( $links, $file ) {
 		if ( WC_PLUGIN_BASENAME === $file ) {
 			$row_meta = array(
-				'docs'    => '<a href="' . esc_url( apply_filters( 'woocommerce_docs_url', 'https://docs.woocommerce.com/documentation/plugins/woocommerce/' ) ) . '" aria-label="' . esc_attr__( 'View WooCommerce documentation', 'classic-commerce' ) . '" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Docs', 'classic-commerce' ) . '</a>',
+				'docs'    => '<a href="' . esc_url( apply_filters( 'woocommerce_docs_url', 'https://classiccommerce.cc/docs/' ) ) . '" aria-label="' . esc_attr__( 'View Classic Commerce documentation', 'classic-commerce' ) . '" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Docs', 'classic-commerce' ) . '</a>',
 				'apidocs' => '<a href="' . esc_url( apply_filters( 'woocommerce_apidocs_url', 'https://docs.woocommerce.com/wc-apidocs/' ) ) . '" aria-label="' . esc_attr__( 'View WooCommerce API docs', 'classic-commerce' ) . '" target="_blank" rel="noopener noreferrer">' . esc_html__( 'API docs', 'classic-commerce' ) . '</a>',
 				'support' => '<a href="' . esc_url( apply_filters( 'woocommerce_support_url', 'https://github.com/ClassicPress-plugins/classic-commerce/issues' ) ) . '" aria-label="' . esc_attr__( 'Visit issues  support section on github', 'classic-commerce' ) . '" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Support', 'classic-commerce' ) . '</a>',
 			);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Classic Commerce Contributing guideline](https://github.com/ClassicPress-plugins/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Now that we are getting CC docs in place we should change the remaining two links from Woo docs to CC docs.

Closes #275

### How to test the changes in this Pull Request:

1. Copy the 2 changed files to a test site
2. Visit the help section and click on "please refer to the documentation" link in top line
3. Confirm open CC docs
4. Run the setup wizard
5. In the final step click on the link in the footer
6. Confirm opens CC docs

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you included screenshots before/after your changes, if applicable?


