### PR TITLE
Change woo docs links to CC in template files

### DIFF
--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -156,7 +156,7 @@ function wc_update_order( $args ) {
 function wc_get_template_part( $slug, $name = '' ) {
 	$template = '';
 
-	// Look in yourtheme/slug-name.php and yourtheme/woocommerce/slug-name.php.
+	// Look in yourtheme/slug-name.php and yourtheme/classic-commerce/slug-name.php.
 	if ( $name && ! WC_TEMPLATE_DEBUG_MODE ) {
 		$template = locate_template( array( "{$slug}-{$name}.php", WC()->template_path() . "{$slug}-{$name}.php" ) );
 	}
@@ -166,7 +166,7 @@ function wc_get_template_part( $slug, $name = '' ) {
 		$template = WC()->plugin_path() . "/templates/{$slug}-{$name}.php";
 	}
 
-	// If template file doesn't exist, look in yourtheme/slug.php and yourtheme/woocommerce/slug.php.
+	// If template file doesn't exist, look in yourtheme/slug.php and yourtheme/classic-commerce/slug.php.
 	if ( ! $template && ! WC_TEMPLATE_DEBUG_MODE ) {
 		$template = locate_template( array( "{$slug}.php", WC()->template_path() . "{$slug}.php" ) );
 	}

--- a/templates/archive-product.php
+++ b/templates/archive-product.php
@@ -2,7 +2,7 @@
 /**
  * The Template for displaying product archives, including the main shop page which is a post type archive
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/archive-product.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/archive-product.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates

--- a/templates/archive-product.php
+++ b/templates/archive-product.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/archive-product.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-3.4.0
  */

--- a/templates/auth/footer.php
+++ b/templates/auth/footer.php
@@ -2,7 +2,7 @@
 /**
  * Auth footer
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/auth/footer.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/auth/footer.php.
  *
  * @see 	https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/auth/footer.php
+++ b/templates/auth/footer.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/auth/footer.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see 	https://docs.woocommerce.com/document/template-structure/
+ * @see 	https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates/Auth
  * @version WC-2.4.0

--- a/templates/auth/form-grant-access.php
+++ b/templates/auth/form-grant-access.php
@@ -2,7 +2,7 @@
 /**
  * Auth form grant access
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/auth/form-grant-access.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/auth/form-grant-access.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/auth/form-grant-access.php
+++ b/templates/auth/form-grant-access.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/auth/form-grant-access.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates/Auth
  * @version WC-2.4.0

--- a/templates/auth/form-login.php
+++ b/templates/auth/form-login.php
@@ -2,7 +2,7 @@
 /**
  * Auth form login
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/auth/form-login.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/auth/form-login.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Auth

--- a/templates/auth/form-login.php
+++ b/templates/auth/form-login.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/auth/form-login.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Auth
  * @version WC-3.4.0
  */

--- a/templates/auth/header.php
+++ b/templates/auth/header.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/auth/header.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates/Auth
  * @version WC-2.4.0

--- a/templates/auth/header.php
+++ b/templates/auth/header.php
@@ -2,7 +2,7 @@
 /**
  * Auth header
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/auth/header.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/auth/header.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/cart/cart-empty.php
+++ b/templates/cart/cart-empty.php
@@ -2,7 +2,7 @@
 /**
  * Empty cart page
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/cart/cart-empty.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/cart/cart-empty.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates

--- a/templates/cart/cart-empty.php
+++ b/templates/cart/cart-empty.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/cart/cart-empty.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-3.5.0
  */

--- a/templates/cart/cart-item-data.php
+++ b/templates/cart/cart-item-data.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/cart/cart-item-data.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-2.4.0

--- a/templates/cart/cart-item-data.php
+++ b/templates/cart/cart-item-data.php
@@ -2,7 +2,7 @@
 /**
  * Cart item data (when outputting non-flat)
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/cart/cart-item-data.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/cart/cart-item-data.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/cart/cart-shipping.php
+++ b/templates/cart/cart-shipping.php
@@ -6,9 +6,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/cart/cart-shipping.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-3.5.0
  */

--- a/templates/cart/cart-shipping.php
+++ b/templates/cart/cart-shipping.php
@@ -4,7 +4,7 @@
  *
  * In 2.1 we show methods per package. This allows for multiple methods per order if so desired.
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/cart/cart-shipping.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/cart/cart-shipping.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates

--- a/templates/cart/cart-totals.php
+++ b/templates/cart/cart-totals.php
@@ -2,7 +2,7 @@
 /**
  * Cart totals
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/cart/cart-totals.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/cart/cart-totals.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/cart/cart-totals.php
+++ b/templates/cart/cart-totals.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/cart/cart-totals.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-2.3.6

--- a/templates/cart/cart.php
+++ b/templates/cart/cart.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/cart/cart.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-3.5.0
  */

--- a/templates/cart/cart.php
+++ b/templates/cart/cart.php
@@ -2,7 +2,7 @@
 /**
  * Cart Page
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/cart/cart.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/cart/cart.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates

--- a/templates/cart/cross-sells.php
+++ b/templates/cart/cross-sells.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/cart/cross-sells.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-3.0.0

--- a/templates/cart/cross-sells.php
+++ b/templates/cart/cross-sells.php
@@ -2,7 +2,7 @@
 /**
  * Cross-sells
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/cart/cross-sells.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/cart/cross-sells.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/cart/mini-cart.php
+++ b/templates/cart/mini-cart.php
@@ -6,9 +6,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/cart/mini-cart.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-3.5.0

--- a/templates/cart/mini-cart.php
+++ b/templates/cart/mini-cart.php
@@ -4,7 +4,7 @@
  *
  * Contains the markup for the mini-cart, used by the cart widget.
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/cart/mini-cart.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/cart/mini-cart.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/cart/proceed-to-checkout-button.php
+++ b/templates/cart/proceed-to-checkout-button.php
@@ -6,9 +6,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/cart/proceed-to-checkout-button.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-2.4.0

--- a/templates/cart/proceed-to-checkout-button.php
+++ b/templates/cart/proceed-to-checkout-button.php
@@ -4,7 +4,7 @@
  *
  * Contains the markup for the proceed to checkout button on the cart.
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/cart/proceed-to-checkout-button.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/cart/proceed-to-checkout-button.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/cart/shipping-calculator.php
+++ b/templates/cart/shipping-calculator.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/cart/shipping-calculator.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-3.5.0
  */

--- a/templates/cart/shipping-calculator.php
+++ b/templates/cart/shipping-calculator.php
@@ -2,7 +2,7 @@
 /**
  * Shipping Calculator
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/cart/shipping-calculator.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/cart/shipping-calculator.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates

--- a/templates/checkout/cart-errors.php
+++ b/templates/checkout/cart-errors.php
@@ -2,7 +2,7 @@
 /**
  * Cart errors page
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/checkout/cart-errors.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/checkout/cart-errors.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates

--- a/templates/checkout/cart-errors.php
+++ b/templates/checkout/cart-errors.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/checkout/cart-errors.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-3.5.0
  */

--- a/templates/checkout/form-billing.php
+++ b/templates/checkout/form-billing.php
@@ -2,7 +2,7 @@
 /**
  * Checkout billing information form
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/checkout/form-billing.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/checkout/form-billing.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/checkout/form-billing.php
+++ b/templates/checkout/form-billing.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/checkout/form-billing.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-3.0.9

--- a/templates/checkout/form-checkout.php
+++ b/templates/checkout/form-checkout.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/checkout/form-checkout.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-3.5.0
  */

--- a/templates/checkout/form-checkout.php
+++ b/templates/checkout/form-checkout.php
@@ -2,7 +2,7 @@
 /**
  * Checkout Form
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/checkout/form-checkout.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/checkout/form-checkout.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates

--- a/templates/checkout/form-coupon.php
+++ b/templates/checkout/form-coupon.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/checkout/form-coupon.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-3.4.4
  */

--- a/templates/checkout/form-coupon.php
+++ b/templates/checkout/form-coupon.php
@@ -2,7 +2,7 @@
 /**
  * Checkout coupon form
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/checkout/form-coupon.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/checkout/form-coupon.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates

--- a/templates/checkout/form-login.php
+++ b/templates/checkout/form-login.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/checkout/form-login.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-3.4.0
  */

--- a/templates/checkout/form-login.php
+++ b/templates/checkout/form-login.php
@@ -2,7 +2,7 @@
 /**
  * Checkout login form
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/checkout/form-login.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/checkout/form-login.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates

--- a/templates/checkout/form-pay.php
+++ b/templates/checkout/form-pay.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/checkout/form-pay.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-3.4.0
  */

--- a/templates/checkout/form-pay.php
+++ b/templates/checkout/form-pay.php
@@ -2,7 +2,7 @@
 /**
  * Pay for order form
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/checkout/form-pay.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/checkout/form-pay.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates

--- a/templates/checkout/form-shipping.php
+++ b/templates/checkout/form-shipping.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/checkout/form-shipping.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-3.0.9

--- a/templates/checkout/form-shipping.php
+++ b/templates/checkout/form-shipping.php
@@ -2,7 +2,7 @@
 /**
  * Checkout shipping information form
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/checkout/form-shipping.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/checkout/form-shipping.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/checkout/order-receipt.php
+++ b/templates/checkout/order-receipt.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/checkout/order-receipt.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-3.2.0

--- a/templates/checkout/order-receipt.php
+++ b/templates/checkout/order-receipt.php
@@ -2,7 +2,7 @@
 /**
  * Checkout Order Receipt Template
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/checkout/order-receipt.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/checkout/order-receipt.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/checkout/payment-method.php
+++ b/templates/checkout/payment-method.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/checkout/payment-method.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-3.5.0
  */

--- a/templates/checkout/payment-method.php
+++ b/templates/checkout/payment-method.php
@@ -2,7 +2,7 @@
 /**
  * Output a single payment method
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/checkout/payment-method.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/checkout/payment-method.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates

--- a/templates/checkout/payment.php
+++ b/templates/checkout/payment.php
@@ -2,7 +2,7 @@
 /**
  * Checkout Payment Section
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/checkout/payment.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/checkout/payment.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates

--- a/templates/checkout/payment.php
+++ b/templates/checkout/payment.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/checkout/payment.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-3.4.0
  */

--- a/templates/checkout/review-order.php
+++ b/templates/checkout/review-order.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/checkout/review-order.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-3.3.0

--- a/templates/checkout/review-order.php
+++ b/templates/checkout/review-order.php
@@ -2,7 +2,7 @@
 /**
  * Review order table
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/checkout/review-order.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/checkout/review-order.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/checkout/thankyou.php
+++ b/templates/checkout/thankyou.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/checkout/thankyou.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-3.2.0

--- a/templates/checkout/thankyou.php
+++ b/templates/checkout/thankyou.php
@@ -2,7 +2,7 @@
 /**
  * Thankyou page
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/checkout/thankyou.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/checkout/thankyou.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/content-product.php
+++ b/templates/content-product.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/content-product.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-3.4.0
  */

--- a/templates/content-product.php
+++ b/templates/content-product.php
@@ -2,7 +2,7 @@
 /**
  * The template for displaying product content within loops
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/content-product.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/content-product.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates

--- a/templates/content-product_cat.php
+++ b/templates/content-product_cat.php
@@ -2,7 +2,7 @@
 /**
  * The template for displaying product category thumbnails within loops
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/content-product_cat.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/content-product_cat.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/content-product_cat.php
+++ b/templates/content-product_cat.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/content-product_cat.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-2.6.1

--- a/templates/content-single-product.php
+++ b/templates/content-single-product.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/content-single-product.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-3.4.0
  */

--- a/templates/content-single-product.php
+++ b/templates/content-single-product.php
@@ -2,7 +2,7 @@
 /**
  * The template for displaying product content in the single-product.php template
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/content-single-product.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/content-single-product.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates

--- a/templates/content-widget-product.php
+++ b/templates/content-widget-product.php
@@ -3,9 +3,8 @@
  * The template for displaying product widget entries.
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/content-widget-product.php.
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-3.5.2
  */

--- a/templates/content-widget-product.php
+++ b/templates/content-widget-product.php
@@ -2,7 +2,7 @@
 /**
  * The template for displaying product widget entries.
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/content-widget-product.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/content-widget-product.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates

--- a/templates/content-widget-reviews.php
+++ b/templates/content-widget-reviews.php
@@ -2,7 +2,7 @@
 /**
  * The template for displaying product widget entries.
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/content-widget-reviews.php
+ * This template can be overridden by copying it to yourtheme/classic-commerce/content-widget-reviews.php
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates

--- a/templates/content-widget-reviews.php
+++ b/templates/content-widget-reviews.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/content-widget-reviews.php
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-3.4.0
  */

--- a/templates/emails/admin-cancelled-order.php
+++ b/templates/emails/admin-cancelled-order.php
@@ -2,7 +2,7 @@
 /**
  * Admin cancelled order email
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/emails/admin-cancelled-order.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/emails/admin-cancelled-order.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails

--- a/templates/emails/admin-cancelled-order.php
+++ b/templates/emails/admin-cancelled-order.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/emails/admin-cancelled-order.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails
  * @version WC-3.5.0
  */

--- a/templates/emails/admin-failed-order.php
+++ b/templates/emails/admin-failed-order.php
@@ -2,7 +2,7 @@
 /**
  * Admin failed order email
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/emails/admin-failed-order.php
+ * This template can be overridden by copying it to yourtheme/classic-commerce/emails/admin-failed-order.php
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails

--- a/templates/emails/admin-failed-order.php
+++ b/templates/emails/admin-failed-order.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/emails/admin-failed-order.php
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails
  * @version WC-3.5.0
  */
@@ -45,7 +43,7 @@ do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, 
 do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
 ?>
 <p>
-<?php echo wp_kses_post( __( 'Hopefully they’ll be back. Read more about <a href="https://docs.woocommerce.com/document/managing-orders/#section-10">troubleshooting failed payments</a>.', 'classic-commerce' ) ); ?>
+<?php echo wp_kses_post( __( 'Hopefully they’ll be back. Read more about <a href="https://classiccommerce.cc/usage-and-maintenance/managing-orders/">troubleshooting failed payments</a>.', 'classic-commerce' ) ); ?>
 </p>
 <?php
 

--- a/templates/emails/admin-new-order.php
+++ b/templates/emails/admin-new-order.php
@@ -2,7 +2,7 @@
 /**
  * Admin new order email
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/emails/admin-new-order.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/emails/admin-new-order.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails/HTML

--- a/templates/emails/admin-new-order.php
+++ b/templates/emails/admin-new-order.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/emails/admin-new-order.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails/HTML
  * @version WC-3.5.0
  */

--- a/templates/emails/customer-completed-order.php
+++ b/templates/emails/customer-completed-order.php
@@ -2,7 +2,7 @@
 /**
  * Customer completed order email
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/emails/customer-completed-order.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/emails/customer-completed-order.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails

--- a/templates/emails/customer-completed-order.php
+++ b/templates/emails/customer-completed-order.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/emails/customer-completed-order.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails
  * @version WC-3.5.0
  */

--- a/templates/emails/customer-invoice.php
+++ b/templates/emails/customer-invoice.php
@@ -2,7 +2,7 @@
 /**
  * Customer invoice email
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/emails/customer-invoice.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/emails/customer-invoice.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails

--- a/templates/emails/customer-invoice.php
+++ b/templates/emails/customer-invoice.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/emails/customer-invoice.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails
  * @version WC-3.5.0
  */

--- a/templates/emails/customer-new-account.php
+++ b/templates/emails/customer-new-account.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/emails/customer-new-account.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails
  * @version WC-3.5.2
  */

--- a/templates/emails/customer-new-account.php
+++ b/templates/emails/customer-new-account.php
@@ -2,7 +2,7 @@
 /**
  * Customer new account email
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/emails/customer-new-account.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/emails/customer-new-account.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails

--- a/templates/emails/customer-note.php
+++ b/templates/emails/customer-note.php
@@ -2,7 +2,7 @@
 /**
  * Customer note email
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/emails/customer-note.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/emails/customer-note.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails

--- a/templates/emails/customer-note.php
+++ b/templates/emails/customer-note.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/emails/customer-note.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails
  * @version WC-3.5.0
  */

--- a/templates/emails/customer-on-hold-order.php
+++ b/templates/emails/customer-on-hold-order.php
@@ -2,7 +2,7 @@
 /**
  * Customer on-hold order email
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/emails/customer-on-hold-order.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/emails/customer-on-hold-order.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails

--- a/templates/emails/customer-on-hold-order.php
+++ b/templates/emails/customer-on-hold-order.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/emails/customer-on-hold-order.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails
  * @version WC-3.5.0
  */

--- a/templates/emails/customer-processing-order.php
+++ b/templates/emails/customer-processing-order.php
@@ -2,7 +2,7 @@
 /**
  * Customer processing order email
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/emails/customer-processing-order.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/emails/customer-processing-order.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails

--- a/templates/emails/customer-processing-order.php
+++ b/templates/emails/customer-processing-order.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/emails/customer-processing-order.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails
  * @version WC-3.5.0
  */

--- a/templates/emails/customer-refunded-order.php
+++ b/templates/emails/customer-refunded-order.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/emails/customer-refunded-order.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails
  * @version WC-3.5.0
  */

--- a/templates/emails/customer-refunded-order.php
+++ b/templates/emails/customer-refunded-order.php
@@ -2,7 +2,7 @@
 /**
  * Customer refunded order email
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/emails/customer-refunded-order.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/emails/customer-refunded-order.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails

--- a/templates/emails/customer-reset-password.php
+++ b/templates/emails/customer-reset-password.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/emails/customer-reset-password.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails
  * @version WC-3.5.0
  */

--- a/templates/emails/customer-reset-password.php
+++ b/templates/emails/customer-reset-password.php
@@ -2,7 +2,7 @@
 /**
  * Customer Reset Password email
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/emails/customer-reset-password.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/emails/customer-reset-password.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails

--- a/templates/emails/email-addresses.php
+++ b/templates/emails/email-addresses.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/emails/email-addresses.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates/Emails
  * @version WC-3.2.1

--- a/templates/emails/email-addresses.php
+++ b/templates/emails/email-addresses.php
@@ -2,7 +2,7 @@
 /**
  * Email Addresses
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/emails/email-addresses.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/emails/email-addresses.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/emails/email-customer-details.php
+++ b/templates/emails/email-customer-details.php
@@ -4,7 +4,7 @@
  *
  * This is extra customer data which can be filtered by plugins. It outputs below the order item table.
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/emails/email-customer-details.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/emails/email-customer-details.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/emails/email-customer-details.php
+++ b/templates/emails/email-customer-details.php
@@ -6,9 +6,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/emails/email-customer-details.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates/Emails
  * @version WC-2.5.0

--- a/templates/emails/email-downloads.php
+++ b/templates/emails/email-downloads.php
@@ -2,7 +2,7 @@
 /**
  * Email Downloads.
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/emails/email-downloads.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/emails/email-downloads.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates

--- a/templates/emails/email-downloads.php
+++ b/templates/emails/email-downloads.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/emails/email-downloads.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-3.4.0
  */

--- a/templates/emails/email-footer.php
+++ b/templates/emails/email-footer.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/emails/email-footer.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates/Emails
  * @version WC-2.3.0

--- a/templates/emails/email-footer.php
+++ b/templates/emails/email-footer.php
@@ -2,7 +2,7 @@
 /**
  * Email Footer
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/emails/email-footer.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/emails/email-footer.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/emails/email-header.php
+++ b/templates/emails/email-header.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/emails/email-header.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates/Emails
  * @version WC-2.4.0

--- a/templates/emails/email-header.php
+++ b/templates/emails/email-header.php
@@ -2,7 +2,7 @@
 /**
  * Email Header
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/emails/email-header.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/emails/email-header.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/emails/email-order-details.php
+++ b/templates/emails/email-order-details.php
@@ -2,7 +2,7 @@
 /**
  * Order details table shown in emails.
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/emails/email-order-details.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/emails/email-order-details.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails

--- a/templates/emails/email-order-details.php
+++ b/templates/emails/email-order-details.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/emails/email-order-details.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails
  * @version WC-3.3.1
  */

--- a/templates/emails/email-order-items.php
+++ b/templates/emails/email-order-items.php
@@ -2,7 +2,7 @@
 /**
  * Email Order Items
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/emails/email-order-items.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/emails/email-order-items.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails

--- a/templates/emails/email-order-items.php
+++ b/templates/emails/email-order-items.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/emails/email-order-items.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails
  * @version WC-3.5.0
  */

--- a/templates/emails/email-styles.php
+++ b/templates/emails/email-styles.php
@@ -2,7 +2,7 @@
 /**
  * Email Styles
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/emails/email-styles.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/emails/email-styles.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails

--- a/templates/emails/email-styles.php
+++ b/templates/emails/email-styles.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/emails/email-styles.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails
  * @version WC-3.3.0
  */

--- a/templates/emails/plain/admin-cancelled-order.php
+++ b/templates/emails/plain/admin-cancelled-order.php
@@ -2,7 +2,7 @@
 /**
  * Admin cancelled order email (plain text)
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/admin-cancelled-order.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/emails/plain/admin-cancelled-order.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails/Plain

--- a/templates/emails/plain/admin-cancelled-order.php
+++ b/templates/emails/plain/admin-cancelled-order.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/admin-cancelled-order.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails/Plain
  * @version WC-3.5.0
  */

--- a/templates/emails/plain/admin-failed-order.php
+++ b/templates/emails/plain/admin-failed-order.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/admin-failed-order.php
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails/Plain
  * @version WC-3.5.0
  */
@@ -43,7 +41,7 @@ do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, 
  */
 do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
 
-echo esc_html__( 'Hopefully they’ll be back. Read more about <a href="https://docs.woocommerce.com/document/managing-orders/#section-10">troubleshooting failed payments</a>.', 'classic-commerce' ) . "\n\n";
+echo esc_html__( 'Hopefully they’ll be back. Read more about <a href="https://classiccommerce.cc/usage-and-maintenance/managing-orders/">troubleshooting failed payments</a>.', 'classic-commerce' ) . "\n\n";
 
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 

--- a/templates/emails/plain/admin-failed-order.php
+++ b/templates/emails/plain/admin-failed-order.php
@@ -2,7 +2,7 @@
 /**
  * Admin failed order email (plain text)
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/admin-failed-order.php
+ * This template can be overridden by copying it to yourtheme/classic-commerce/emails/plain/admin-failed-order.php
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails/Plain

--- a/templates/emails/plain/admin-new-order.php
+++ b/templates/emails/plain/admin-new-order.php
@@ -2,7 +2,7 @@
 /**
  * Admin new order email (plain text)
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/admin-new-order.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/emails/plain/admin-new-order.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails/Plain

--- a/templates/emails/plain/admin-new-order.php
+++ b/templates/emails/plain/admin-new-order.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/admin-new-order.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails/Plain
  * @version WC-3.5.0
  */

--- a/templates/emails/plain/customer-completed-order.php
+++ b/templates/emails/plain/customer-completed-order.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/customer-completed-order.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails/Plain
  * @version WC-3.5.0
  */

--- a/templates/emails/plain/customer-completed-order.php
+++ b/templates/emails/plain/customer-completed-order.php
@@ -2,7 +2,7 @@
 /**
  * Customer completed order email (plain text)
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/customer-completed-order.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/emails/plain/customer-completed-order.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails/Plain

--- a/templates/emails/plain/customer-invoice.php
+++ b/templates/emails/plain/customer-invoice.php
@@ -2,7 +2,7 @@
 /**
  * Customer invoice email (plain text)
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/customer-invoice.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/emails/plain/customer-invoice.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails/Plain

--- a/templates/emails/plain/customer-invoice.php
+++ b/templates/emails/plain/customer-invoice.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/customer-invoice.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails/Plain
  * @version WC-3.5.0
  */

--- a/templates/emails/plain/customer-new-account.php
+++ b/templates/emails/plain/customer-new-account.php
@@ -2,7 +2,7 @@
 /**
  * Customer new account email
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/customer-new-account.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/emails/plain/customer-new-account.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails/Plain

--- a/templates/emails/plain/customer-new-account.php
+++ b/templates/emails/plain/customer-new-account.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/customer-new-account.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails/Plain
  * @version WC-3.5.2
  */

--- a/templates/emails/plain/customer-note.php
+++ b/templates/emails/plain/customer-note.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/customer-note.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails/Plain
  * @version WC-3.5.0
  */

--- a/templates/emails/plain/customer-note.php
+++ b/templates/emails/plain/customer-note.php
@@ -2,7 +2,7 @@
 /**
  * Customer note email
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/customer-note.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/emails/plain/customer-note.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails/Plain

--- a/templates/emails/plain/customer-on-hold-order.php
+++ b/templates/emails/plain/customer-on-hold-order.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/customer-on-hold-order.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails/Plain
  * @version WC-3.5.0
  */

--- a/templates/emails/plain/customer-on-hold-order.php
+++ b/templates/emails/plain/customer-on-hold-order.php
@@ -2,7 +2,7 @@
 /**
  * Customer on-hold order email
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/customer-on-hold-order.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/emails/plain/customer-on-hold-order.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails/Plain

--- a/templates/emails/plain/customer-processing-order.php
+++ b/templates/emails/plain/customer-processing-order.php
@@ -2,7 +2,7 @@
 /**
  * Customer processing order email
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/customer-processing-order.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/emails/plain/customer-processing-order.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails/Plain

--- a/templates/emails/plain/customer-processing-order.php
+++ b/templates/emails/plain/customer-processing-order.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/customer-processing-order.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails/Plain
  * @version WC-3.5.0
  */

--- a/templates/emails/plain/customer-refunded-order.php
+++ b/templates/emails/plain/customer-refunded-order.php
@@ -2,7 +2,7 @@
 /**
  * Customer refunded order email (plain text)
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/customer-refunded-order.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/emails/plain/customer-refunded-order.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails/Plain

--- a/templates/emails/plain/customer-refunded-order.php
+++ b/templates/emails/plain/customer-refunded-order.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/customer-refunded-order.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails/Plain
  * @version WC-3.5.0
  */

--- a/templates/emails/plain/customer-reset-password.php
+++ b/templates/emails/plain/customer-reset-password.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/customer-reset-password.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails/Plain
  * @version WC-3.5.0
  */

--- a/templates/emails/plain/customer-reset-password.php
+++ b/templates/emails/plain/customer-reset-password.php
@@ -2,7 +2,7 @@
 /**
  * Customer Reset Password email
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/customer-reset-password.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/emails/plain/customer-reset-password.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails/Plain

--- a/templates/emails/plain/email-addresses.php
+++ b/templates/emails/plain/email-addresses.php
@@ -2,7 +2,7 @@
 /**
  * Email Addresses (plain)
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/email-addresses.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/emails/plain/email-addresses.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails/Plain

--- a/templates/emails/plain/email-addresses.php
+++ b/templates/emails/plain/email-addresses.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/email-addresses.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails/Plain
  * @version WC-3.4.0
  */

--- a/templates/emails/plain/email-customer-details.php
+++ b/templates/emails/plain/email-customer-details.php
@@ -4,7 +4,7 @@
  *
  * This is extra customer data which can be filtered by plugins. It outputs below the order item table.
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/email-addresses.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/emails/plain/email-addresses.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails/Plain

--- a/templates/emails/plain/email-customer-details.php
+++ b/templates/emails/plain/email-customer-details.php
@@ -6,9 +6,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/email-addresses.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails/Plain
  * @version WC-3.4.0
  */

--- a/templates/emails/plain/email-downloads.php
+++ b/templates/emails/plain/email-downloads.php
@@ -2,7 +2,7 @@
 /**
  * Email Downloads.
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/email-downloads.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/emails/plain/email-downloads.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates

--- a/templates/emails/plain/email-downloads.php
+++ b/templates/emails/plain/email-downloads.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/email-downloads.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-3.4.0
  */

--- a/templates/emails/plain/email-order-details.php
+++ b/templates/emails/plain/email-order-details.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/email-order-details.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails
  * @version WC-3.5.0
  */

--- a/templates/emails/plain/email-order-details.php
+++ b/templates/emails/plain/email-order-details.php
@@ -2,7 +2,7 @@
 /**
  * Order details table shown in emails.
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/email-order-details.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/emails/plain/email-order-details.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates/Emails

--- a/templates/emails/plain/email-order-items.php
+++ b/templates/emails/plain/email-order-items.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/email-order-items.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates/Emails/Plain
  * @version WC-3.2.0

--- a/templates/emails/plain/email-order-items.php
+++ b/templates/emails/plain/email-order-items.php
@@ -2,7 +2,7 @@
 /**
  * Email Order Items (plain)
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/email-order-items.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/emails/plain/email-order-items.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/global/breadcrumb.php
+++ b/templates/global/breadcrumb.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/global/breadcrumb.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-2.3.0

--- a/templates/global/breadcrumb.php
+++ b/templates/global/breadcrumb.php
@@ -2,7 +2,7 @@
 /**
  * Shop breadcrumb
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/global/breadcrumb.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/global/breadcrumb.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/global/form-login.php
+++ b/templates/global/form-login.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/global/form-login.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-3.3.0

--- a/templates/global/form-login.php
+++ b/templates/global/form-login.php
@@ -2,7 +2,7 @@
 /**
  * Login form
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/global/form-login.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/global/form-login.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/global/quantity-input.php
+++ b/templates/global/quantity-input.php
@@ -2,7 +2,7 @@
 /**
  * Product quantity inputs
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/global/quantity-input.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/global/quantity-input.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates

--- a/templates/global/quantity-input.php
+++ b/templates/global/quantity-input.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/global/quantity-input.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-3.4.0
  */

--- a/templates/global/sidebar.php
+++ b/templates/global/sidebar.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/global/sidebar.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-1.6.4

--- a/templates/global/sidebar.php
+++ b/templates/global/sidebar.php
@@ -2,7 +2,7 @@
 /**
  * Sidebar
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/global/sidebar.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/global/sidebar.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/global/wrapper-end.php
+++ b/templates/global/wrapper-end.php
@@ -2,7 +2,7 @@
 /**
  * Content wrappers
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/global/wrapper-end.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/global/wrapper-end.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/global/wrapper-end.php
+++ b/templates/global/wrapper-end.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/global/wrapper-end.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-3.3.0

--- a/templates/global/wrapper-start.php
+++ b/templates/global/wrapper-start.php
@@ -2,7 +2,7 @@
 /**
  * Content wrappers
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/global/wrapper-start.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/global/wrapper-start.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/global/wrapper-start.php
+++ b/templates/global/wrapper-start.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/global/wrapper-start.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-3.3.0

--- a/templates/loop/add-to-cart.php
+++ b/templates/loop/add-to-cart.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/loop/add-to-cart.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-3.3.0

--- a/templates/loop/add-to-cart.php
+++ b/templates/loop/add-to-cart.php
@@ -2,7 +2,7 @@
 /**
  * Loop Add to Cart
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/loop/add-to-cart.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/loop/add-to-cart.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/loop/loop-end.php
+++ b/templates/loop/loop-end.php
@@ -2,7 +2,7 @@
 /**
  * Product Loop End
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/loop/loop-end.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/loop/loop-end.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/loop/loop-end.php
+++ b/templates/loop/loop-end.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/loop/loop-end.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-2.0.0

--- a/templates/loop/loop-start.php
+++ b/templates/loop/loop-start.php
@@ -2,7 +2,7 @@
 /**
  * Product Loop Start
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/loop/loop-start.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/loop/loop-start.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/loop/loop-start.php
+++ b/templates/loop/loop-start.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/loop/loop-start.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-3.3.0

--- a/templates/loop/no-products-found.php
+++ b/templates/loop/no-products-found.php
@@ -2,7 +2,7 @@
 /**
  * Displayed when no products are found matching the current query
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/loop/no-products-found.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/loop/no-products-found.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/loop/no-products-found.php
+++ b/templates/loop/no-products-found.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/loop/no-products-found.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-2.0.0

--- a/templates/loop/orderby.php
+++ b/templates/loop/orderby.php
@@ -2,7 +2,7 @@
 /**
  * Show options for ordering
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/loop/orderby.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/loop/orderby.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/loop/orderby.php
+++ b/templates/loop/orderby.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/loop/orderby.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-3.3.0

--- a/templates/loop/pagination.php
+++ b/templates/loop/pagination.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/loop/pagination.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-3.3.1
  */

--- a/templates/loop/pagination.php
+++ b/templates/loop/pagination.php
@@ -2,7 +2,7 @@
 /**
  * Pagination - Show numbered pagination for catalog pages
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/loop/pagination.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/loop/pagination.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates

--- a/templates/loop/price.php
+++ b/templates/loop/price.php
@@ -2,7 +2,7 @@
 /**
  * Loop Price
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/loop/price.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/loop/price.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/loop/price.php
+++ b/templates/loop/price.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/loop/price.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-1.6.4

--- a/templates/loop/rating.php
+++ b/templates/loop/rating.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/loop/rating.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-3.0.0

--- a/templates/loop/rating.php
+++ b/templates/loop/rating.php
@@ -2,7 +2,7 @@
 /**
  * Loop Rating
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/loop/rating.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/loop/rating.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/loop/result-count.php
+++ b/templates/loop/result-count.php
@@ -6,9 +6,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/loop/result-count.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-3.3.0

--- a/templates/loop/result-count.php
+++ b/templates/loop/result-count.php
@@ -4,7 +4,7 @@
  *
  * Shows text: Showing x - x of x results.
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/loop/result-count.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/loop/result-count.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/loop/sale-flash.php
+++ b/templates/loop/sale-flash.php
@@ -2,7 +2,7 @@
 /**
  * Product loop sale flash
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/loop/sale-flash.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/loop/sale-flash.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/loop/sale-flash.php
+++ b/templates/loop/sale-flash.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/loop/sale-flash.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-1.6.4

--- a/templates/myaccount/dashboard.php
+++ b/templates/myaccount/dashboard.php
@@ -6,9 +6,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/myaccount/dashboard.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-2.6.0

--- a/templates/myaccount/dashboard.php
+++ b/templates/myaccount/dashboard.php
@@ -4,7 +4,7 @@
  *
  * Shows the first intro screen on the account dashboard.
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/myaccount/dashboard.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/myaccount/dashboard.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/myaccount/downloads.php
+++ b/templates/myaccount/downloads.php
@@ -4,7 +4,7 @@
  *
  * Shows downloads on the account page.
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/myaccount/downloads.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/myaccount/downloads.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/myaccount/downloads.php
+++ b/templates/myaccount/downloads.php
@@ -6,9 +6,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/myaccount/downloads.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-3.2.0

--- a/templates/myaccount/form-add-payment-method.php
+++ b/templates/myaccount/form-add-payment-method.php
@@ -2,7 +2,7 @@
 /**
  * Add payment method form form
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/myaccount/form-add-payment-method.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/myaccount/form-add-payment-method.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates

--- a/templates/myaccount/form-add-payment-method.php
+++ b/templates/myaccount/form-add-payment-method.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/myaccount/form-add-payment-method.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-3.4.0
  */

--- a/templates/myaccount/form-edit-account.php
+++ b/templates/myaccount/form-edit-account.php
@@ -2,7 +2,7 @@
 /**
  * Edit account form
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/myaccount/form-edit-account.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/myaccount/form-edit-account.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates

--- a/templates/myaccount/form-edit-account.php
+++ b/templates/myaccount/form-edit-account.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/myaccount/form-edit-account.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-3.5.0
  */

--- a/templates/myaccount/form-edit-address.php
+++ b/templates/myaccount/form-edit-address.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/myaccount/form-edit-address.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-3.4.0
  */

--- a/templates/myaccount/form-edit-address.php
+++ b/templates/myaccount/form-edit-address.php
@@ -2,7 +2,7 @@
 /**
  * Edit address form
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/myaccount/form-edit-address.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/myaccount/form-edit-address.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates

--- a/templates/myaccount/form-login.php
+++ b/templates/myaccount/form-login.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/myaccount/form-login.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-3.5.0
  */

--- a/templates/myaccount/form-login.php
+++ b/templates/myaccount/form-login.php
@@ -2,7 +2,7 @@
 /**
  * Login Form
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/myaccount/form-login.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/myaccount/form-login.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates

--- a/templates/myaccount/form-lost-password.php
+++ b/templates/myaccount/form-lost-password.php
@@ -2,7 +2,7 @@
 /**
  * Lost password form
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/myaccount/form-lost-password.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/myaccount/form-lost-password.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates

--- a/templates/myaccount/form-lost-password.php
+++ b/templates/myaccount/form-lost-password.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/myaccount/form-lost-password.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-3.5.2
  */

--- a/templates/myaccount/form-reset-password.php
+++ b/templates/myaccount/form-reset-password.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/myaccount/form-reset-password.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-3.5.0
  */

--- a/templates/myaccount/form-reset-password.php
+++ b/templates/myaccount/form-reset-password.php
@@ -2,7 +2,7 @@
 /**
  * Lost password reset form.
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/myaccount/form-reset-password.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/myaccount/form-reset-password.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates

--- a/templates/myaccount/lost-password-confirmation.php
+++ b/templates/myaccount/lost-password-confirmation.php
@@ -2,7 +2,7 @@
 /**
  * Lost password confirmation text.
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/myaccount/lost-password-confirmation.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/myaccount/lost-password-confirmation.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates

--- a/templates/myaccount/lost-password-confirmation.php
+++ b/templates/myaccount/lost-password-confirmation.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/myaccount/lost-password-confirmation.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-3.5.2
  */

--- a/templates/myaccount/my-account.php
+++ b/templates/myaccount/my-account.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/myaccount/my-account.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-3.5.0
  */

--- a/templates/myaccount/my-account.php
+++ b/templates/myaccount/my-account.php
@@ -2,7 +2,7 @@
 /**
  * My Account page
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/myaccount/my-account.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/myaccount/my-account.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates

--- a/templates/myaccount/my-address.php
+++ b/templates/myaccount/my-address.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/myaccount/my-address.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-2.6.0

--- a/templates/myaccount/my-address.php
+++ b/templates/myaccount/my-address.php
@@ -2,7 +2,7 @@
 /**
  * My Addresses
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/myaccount/my-address.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/myaccount/my-address.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/myaccount/my-downloads.php
+++ b/templates/myaccount/my-downloads.php
@@ -4,7 +4,7 @@
  *
  * Shows downloads on the account page.
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/myaccount/my-downloads.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/myaccount/my-downloads.php.
  *
  * @see        https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author     WooThemes

--- a/templates/myaccount/my-downloads.php
+++ b/templates/myaccount/my-downloads.php
@@ -6,9 +6,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/myaccount/my-downloads.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see        https://docs.woocommerce.com/document/template-structure/
+ * @see        https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author     WooThemes
  * @package    Classic Commerce/Templates
  * @version    WC-2.0.0

--- a/templates/myaccount/navigation.php
+++ b/templates/myaccount/navigation.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/myaccount/navigation.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-2.6.0

--- a/templates/myaccount/navigation.php
+++ b/templates/myaccount/navigation.php
@@ -2,7 +2,7 @@
 /**
  * My Account navigation
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/myaccount/navigation.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/myaccount/navigation.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/myaccount/orders.php
+++ b/templates/myaccount/orders.php
@@ -6,9 +6,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/myaccount/orders.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-3.2.0

--- a/templates/myaccount/orders.php
+++ b/templates/myaccount/orders.php
@@ -4,7 +4,7 @@
  *
  * Shows orders on the account page.
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/myaccount/orders.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/myaccount/orders.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/myaccount/payment-methods.php
+++ b/templates/myaccount/payment-methods.php
@@ -6,9 +6,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/myaccount/payment-methods.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-2.6.0

--- a/templates/myaccount/payment-methods.php
+++ b/templates/myaccount/payment-methods.php
@@ -4,7 +4,7 @@
  *
  * Shows customer payment methods on the account page.
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/myaccount/payment-methods.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/myaccount/payment-methods.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/myaccount/view-order.php
+++ b/templates/myaccount/view-order.php
@@ -4,7 +4,7 @@
  *
  * Shows the details of a particular order on the account page.
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/myaccount/view-order.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/myaccount/view-order.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/myaccount/view-order.php
+++ b/templates/myaccount/view-order.php
@@ -6,9 +6,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/myaccount/view-order.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-3.0.0

--- a/templates/notices/error.php
+++ b/templates/notices/error.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/notices/error.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-3.5.0
  */

--- a/templates/notices/error.php
+++ b/templates/notices/error.php
@@ -2,7 +2,7 @@
 /**
  * Show error messages
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/notices/error.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/notices/error.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates

--- a/templates/notices/notice.php
+++ b/templates/notices/notice.php
@@ -2,7 +2,7 @@
 /**
  * Show messages
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/notices/notice.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/notices/notice.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates

--- a/templates/notices/notice.php
+++ b/templates/notices/notice.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/notices/notice.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-3.5.0
  */

--- a/templates/notices/success.php
+++ b/templates/notices/success.php
@@ -2,7 +2,7 @@
 /**
  * Show messages
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/notices/success.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/notices/success.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates

--- a/templates/notices/success.php
+++ b/templates/notices/success.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/notices/success.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-3.5.0
  */

--- a/templates/order/form-tracking.php
+++ b/templates/order/form-tracking.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/order/form-tracking.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-3.4.0
  */

--- a/templates/order/form-tracking.php
+++ b/templates/order/form-tracking.php
@@ -2,7 +2,7 @@
 /**
  * Order tracking form
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/order/form-tracking.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/order/form-tracking.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates

--- a/templates/order/order-again.php
+++ b/templates/order/order-again.php
@@ -2,7 +2,7 @@
 /**
  * Order again button
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/order/order-again.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/order/order-again.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates

--- a/templates/order/order-again.php
+++ b/templates/order/order-again.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/order/order-again.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-3.5.0
  */

--- a/templates/order/order-details-customer.php
+++ b/templates/order/order-details-customer.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/order/order-details-customer.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-3.4.4
  */

--- a/templates/order/order-details-customer.php
+++ b/templates/order/order-details-customer.php
@@ -2,7 +2,7 @@
 /**
  * Order Customer Details
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/order/order-details-customer.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/order/order-details-customer.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates

--- a/templates/order/order-details-item.php
+++ b/templates/order/order-details-item.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/order/order-details-item.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-3.0.0

--- a/templates/order/order-details-item.php
+++ b/templates/order/order-details-item.php
@@ -2,7 +2,7 @@
 /**
  * Order Item Details
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/order/order-details-item.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/order/order-details-item.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/order/order-details.php
+++ b/templates/order/order-details.php
@@ -2,7 +2,7 @@
 /**
  * Order details
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/order/order-details.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/order/order-details.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/order/order-details.php
+++ b/templates/order/order-details.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/order/order-details.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-3.5.2

--- a/templates/order/order-downloads.php
+++ b/templates/order/order-downloads.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/order/order-downloads.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  Automattic
  * @package ClassicCommerce/Templates
  * @version WC-3.3.0

--- a/templates/order/order-downloads.php
+++ b/templates/order/order-downloads.php
@@ -2,7 +2,7 @@
 /**
  * Order Downloads.
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/order/order-downloads.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/order/order-downloads.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  Automattic

--- a/templates/order/tracking.php
+++ b/templates/order/tracking.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/order/tracking.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-2.2.0

--- a/templates/order/tracking.php
+++ b/templates/order/tracking.php
@@ -2,7 +2,7 @@
 /**
  * Order tracking
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/order/tracking.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/order/tracking.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/product-searchform.php
+++ b/templates/product-searchform.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/product-searchform.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-3.3.0

--- a/templates/product-searchform.php
+++ b/templates/product-searchform.php
@@ -2,7 +2,7 @@
 /**
  * The template for displaying product search form
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/product-searchform.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/product-searchform.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/single-product-reviews.php
+++ b/templates/single-product-reviews.php
@@ -2,7 +2,7 @@
 /**
  * Display single product reviews (comments)
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/single-product-reviews.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/single-product-reviews.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/single-product-reviews.php
+++ b/templates/single-product-reviews.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/single-product-reviews.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-3.5.0

--- a/templates/single-product.php
+++ b/templates/single-product.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/single-product.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-1.6.4

--- a/templates/single-product.php
+++ b/templates/single-product.php
@@ -2,7 +2,7 @@
 /**
  * The Template for displaying all single products
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/single-product.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/single-product.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/single-product/add-to-cart/external.php
+++ b/templates/single-product/add-to-cart/external.php
@@ -2,7 +2,7 @@
 /**
  * External product add to cart
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/single-product/add-to-cart/external.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/single-product/add-to-cart/external.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates

--- a/templates/single-product/add-to-cart/external.php
+++ b/templates/single-product/add-to-cart/external.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/single-product/add-to-cart/external.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-3.4.0
  */

--- a/templates/single-product/add-to-cart/grouped.php
+++ b/templates/single-product/add-to-cart/grouped.php
@@ -2,7 +2,7 @@
 /**
  * Grouped product add to cart
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/single-product/add-to-cart/grouped.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/single-product/add-to-cart/grouped.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates

--- a/templates/single-product/add-to-cart/grouped.php
+++ b/templates/single-product/add-to-cart/grouped.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/single-product/add-to-cart/grouped.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-3.4.0
  */

--- a/templates/single-product/add-to-cart/simple.php
+++ b/templates/single-product/add-to-cart/simple.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/single-product/add-to-cart/simple.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-3.4.0
  */

--- a/templates/single-product/add-to-cart/simple.php
+++ b/templates/single-product/add-to-cart/simple.php
@@ -2,7 +2,7 @@
 /**
  * Simple product add to cart
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/single-product/add-to-cart/simple.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/single-product/add-to-cart/simple.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates

--- a/templates/single-product/add-to-cart/variable.php
+++ b/templates/single-product/add-to-cart/variable.php
@@ -2,7 +2,7 @@
 /**
  * Variable product add to cart
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/single-product/add-to-cart/variable.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/single-product/add-to-cart/variable.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates

--- a/templates/single-product/add-to-cart/variable.php
+++ b/templates/single-product/add-to-cart/variable.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/single-product/add-to-cart/variable.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-3.5.5
  */

--- a/templates/single-product/add-to-cart/variation-add-to-cart-button.php
+++ b/templates/single-product/add-to-cart/variation-add-to-cart-button.php
@@ -2,7 +2,7 @@
 /**
  * Single variation cart button
  *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-3.4.0
  */

--- a/templates/single-product/add-to-cart/variation.php
+++ b/templates/single-product/add-to-cart/variation.php
@@ -5,7 +5,7 @@
  * This is a javascript-based template for single variations (see https://codex.wordpress.org/Javascript_Reference/wp.template).
  * The values will be dynamically replaced after selecting attributes.
  *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-2.5.0

--- a/templates/single-product/meta.php
+++ b/templates/single-product/meta.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/single-product/meta.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-3.0.0

--- a/templates/single-product/meta.php
+++ b/templates/single-product/meta.php
@@ -2,7 +2,7 @@
 /**
  * Single Product Meta
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/single-product/meta.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/single-product/meta.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/single-product/photoswipe.php
+++ b/templates/single-product/photoswipe.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/single-product/photoswipe.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-3.0.0

--- a/templates/single-product/photoswipe.php
+++ b/templates/single-product/photoswipe.php
@@ -2,7 +2,7 @@
 /**
  * Photoswipe markup
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/single-product/photoswipe.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/single-product/photoswipe.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/single-product/price.php
+++ b/templates/single-product/price.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/single-product/price.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-3.0.0

--- a/templates/single-product/price.php
+++ b/templates/single-product/price.php
@@ -2,7 +2,7 @@
 /**
  * Single Product Price
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/single-product/price.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/single-product/price.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/single-product/product-attributes.php
+++ b/templates/single-product/product-attributes.php
@@ -6,9 +6,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/single-product/product-attributes.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-3.1.0

--- a/templates/single-product/product-attributes.php
+++ b/templates/single-product/product-attributes.php
@@ -4,7 +4,7 @@
  *
  * Used by list_attributes() in the products class.
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/single-product/product-attributes.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/single-product/product-attributes.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/single-product/product-image.php
+++ b/templates/single-product/product-image.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/single-product/product-image.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-3.5.1
  */

--- a/templates/single-product/product-image.php
+++ b/templates/single-product/product-image.php
@@ -2,7 +2,7 @@
 /**
  * Single Product Image
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/single-product/product-image.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/single-product/product-image.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates

--- a/templates/single-product/product-thumbnails.php
+++ b/templates/single-product/product-thumbnails.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/single-product/product-thumbnails.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-3.5.1
  */

--- a/templates/single-product/product-thumbnails.php
+++ b/templates/single-product/product-thumbnails.php
@@ -2,7 +2,7 @@
 /**
  * Single Product Thumbnails
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/single-product/product-thumbnails.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/single-product/product-thumbnails.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates

--- a/templates/single-product/rating.php
+++ b/templates/single-product/rating.php
@@ -2,7 +2,7 @@
 /**
  * Single Product Rating
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/single-product/rating.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/single-product/rating.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/single-product/rating.php
+++ b/templates/single-product/rating.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/single-product/rating.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-3.1.0

--- a/templates/single-product/related.php
+++ b/templates/single-product/related.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/single-product/related.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-3.0.0

--- a/templates/single-product/related.php
+++ b/templates/single-product/related.php
@@ -2,7 +2,7 @@
 /**
  * Related Products
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/single-product/related.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/single-product/related.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/single-product/review-meta.php
+++ b/templates/single-product/review-meta.php
@@ -2,7 +2,7 @@
 /**
  * The template to display the reviewers meta data (name, verified owner, review date)
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/single-product/review-meta.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/single-product/review-meta.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates

--- a/templates/single-product/review-meta.php
+++ b/templates/single-product/review-meta.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/single-product/review-meta.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-3.4.0
  */

--- a/templates/single-product/review-rating.php
+++ b/templates/single-product/review-rating.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/review-rating.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-3.1.0

--- a/templates/single-product/review-rating.php
+++ b/templates/single-product/review-rating.php
@@ -2,7 +2,7 @@
 /**
  * The template to display the reviewers star rating in reviews
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/review-rating.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/review-rating.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/single-product/review.php
+++ b/templates/single-product/review.php
@@ -4,7 +4,7 @@
  *
  * Closing li is left out on purpose!.
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/single-product/review.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/single-product/review.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/single-product/review.php
+++ b/templates/single-product/review.php
@@ -6,9 +6,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/single-product/review.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-2.6.0

--- a/templates/single-product/sale-flash.php
+++ b/templates/single-product/sale-flash.php
@@ -2,7 +2,7 @@
 /**
  * Single Product Sale Flash
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/single-product/sale-flash.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/single-product/sale-flash.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/single-product/sale-flash.php
+++ b/templates/single-product/sale-flash.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/single-product/sale-flash.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-1.6.4

--- a/templates/single-product/share.php
+++ b/templates/single-product/share.php
@@ -4,7 +4,7 @@
  *
  * Sharing plugins can hook into here or you can add your own code directly.
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/single-product/share.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/single-product/share.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates

--- a/templates/single-product/share.php
+++ b/templates/single-product/share.php
@@ -6,9 +6,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/single-product/share.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-3.5.0
  */

--- a/templates/single-product/short-description.php
+++ b/templates/single-product/short-description.php
@@ -2,7 +2,7 @@
 /**
  * Single product short description
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/single-product/short-description.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/single-product/short-description.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  Automattic

--- a/templates/single-product/short-description.php
+++ b/templates/single-product/short-description.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/single-product/short-description.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  Automattic
  * @package ClassicCommerce/Templates
  * @version WC-3.3.0

--- a/templates/single-product/stock.php
+++ b/templates/single-product/stock.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/single-product/stock.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-3.0.0

--- a/templates/single-product/stock.php
+++ b/templates/single-product/stock.php
@@ -2,7 +2,7 @@
 /**
  * Single Product stock.
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/single-product/stock.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/single-product/stock.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/single-product/tabs/additional-information.php
+++ b/templates/single-product/tabs/additional-information.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/single-product/tabs/additional-information.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-3.0.0

--- a/templates/single-product/tabs/additional-information.php
+++ b/templates/single-product/tabs/additional-information.php
@@ -2,7 +2,7 @@
 /**
  * Additional Information tab
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/single-product/tabs/additional-information.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/single-product/tabs/additional-information.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/single-product/tabs/description.php
+++ b/templates/single-product/tabs/description.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/single-product/tabs/description.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-2.0.0

--- a/templates/single-product/tabs/description.php
+++ b/templates/single-product/tabs/description.php
@@ -2,7 +2,7 @@
 /**
  * Description tab
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/single-product/tabs/description.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/single-product/tabs/description.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/single-product/tabs/tabs.php
+++ b/templates/single-product/tabs/tabs.php
@@ -2,7 +2,7 @@
 /**
  * Single Product tabs
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/single-product/tabs/tabs.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/single-product/tabs/tabs.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/single-product/tabs/tabs.php
+++ b/templates/single-product/tabs/tabs.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/single-product/tabs/tabs.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-2.4.0

--- a/templates/single-product/title.php
+++ b/templates/single-product/title.php
@@ -2,7 +2,7 @@
 /**
  * Single Product title
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/single-product/title.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/single-product/title.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/single-product/title.php
+++ b/templates/single-product/title.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/single-product/title.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-1.6.4

--- a/templates/single-product/up-sells.php
+++ b/templates/single-product/up-sells.php
@@ -2,7 +2,7 @@
 /**
  * Single Product Up-Sells
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/single-product/up-sells.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/single-product/up-sells.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes

--- a/templates/single-product/up-sells.php
+++ b/templates/single-product/up-sells.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/single-product/up-sells.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @author  WooThemes
  * @package ClassicCommerce/Templates
  * @version WC-3.0.0

--- a/templates/taxonomy-product_cat.php
+++ b/templates/taxonomy-product_cat.php
@@ -2,7 +2,7 @@
 /**
  * The Template for displaying products in a product category. Simply includes the archive template
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/taxonomy-product_cat.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/taxonomy-product_cat.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates

--- a/templates/taxonomy-product_cat.php
+++ b/templates/taxonomy-product_cat.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/taxonomy-product_cat.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-1.6.4
  */

--- a/templates/taxonomy-product_tag.php
+++ b/templates/taxonomy-product_tag.php
@@ -4,9 +4,7 @@
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/taxonomy-product_tag.php.
  *
- * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
- *
- * @see     https://docs.woocommerce.com/document/template-structure/
+ * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates
  * @version WC-1.6.4
  */

--- a/templates/taxonomy-product_tag.php
+++ b/templates/taxonomy-product_tag.php
@@ -2,7 +2,7 @@
 /**
  * The Template for displaying products in a product tag. Simply includes the archive template
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/taxonomy-product_tag.php.
+ * This template can be overridden by copying it to yourtheme/classic-commerce/taxonomy-product_tag.php.
  *
  * @see     https://classiccommerce.cc/docs/installation-and-setup/template-structure/
  * @package ClassicCommerce/Templates


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Classic Commerce Contributing guideline](https://github.com/ClassicPress-plugins/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Change all occurrences of urls to woocommerce docs to our version at classiccommerce.cc in the template files.

### How to test the changes in this Pull Request:

1. Visually check all new links in the files

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you included screenshots before/after your changes, if applicable?


