### PR TITLE
Fix for CC icon not showing in some installations

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,8 @@
 == Changelog ==
 
+= 1.0.1 - 2020-10-17
+Fixed: CC icon not showing in some installations #289
+
 = 1.0.0 - 2020-10-01
 New: Complete new set of sample products created specifically for CC #284
 Updated: All documentation links now point to classiccommerce.cc #274, #278, #281
@@ -9,7 +12,6 @@ Updated: node-sass and handlebars dependencies #258, #259
 Improved: Stock levels are now hidden on the dashboard widget if inventory is disabled #261
 Improved: Additional checks made during build process #269
 Tweaks: Some well-hidden instances of WC purple changes to CC aqua #270, #271
-
 
 = 1.0.0-rc.2 - 2020-08-29
 Fixed: Corrected color of two images to CC aqua, missed in rc1. #255

--- a/classic-commerce.php
+++ b/classic-commerce.php
@@ -150,11 +150,6 @@ if ( $_cc_can_load ) {
 		define( 'WC_PLUGIN_FILE', __FILE__ );
 	}
 
-	// Define WC_PLUGIN_DIR.
-	if ( ! defined( 'WC_PLUGIN_DIR' ) ) {
-		define( 'WC_PLUGIN_DIR', plugin_dir_path( WC_PLUGIN_FILE ) );
-	}
-
 	// Include the main WooCommerce class.
 	if ( ! class_exists( 'WooCommerce' ) ) {
 		include_once dirname( __FILE__ ) . '/includes/class-woocommerce.php';

--- a/classic-commerce.php
+++ b/classic-commerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: Classic Commerce
  * Plugin URI: https://github.com/ClassicPress-plugins/classic-commerce
  * Description: A simple, powerful and independent e-commerce platform. Sell anything with ease.
- * Version: 1.0.0
+ * Version: 1.0.1
  * Author: ClassicPress Research Team
  * Author URI: https://github.com/ClassicPress-plugins/classic-commerce
  * Text Domain: classic-commerce
@@ -148,6 +148,11 @@ if ( $_cc_can_load ) {
 	// Define WC_PLUGIN_FILE.
 	if ( ! defined( 'WC_PLUGIN_FILE' ) ) {
 		define( 'WC_PLUGIN_FILE', __FILE__ );
+	}
+
+	// Define WC_PLUGIN_DIR.
+	if ( ! defined( 'WC_PLUGIN_DIR' ) ) {
+		define( 'WC_PLUGIN_DIR', plugin_dir_path( WC_PLUGIN_FILE ) );
 	}
 
 	// Include the main WooCommerce class.

--- a/includes/admin/class-wc-admin-menus.php
+++ b/includes/admin/class-wc-admin-menus.php
@@ -52,15 +52,20 @@ class WC_Admin_Menus {
 	 */
 	public function admin_menu() {
 		global $menu;
-
-		$icon_svg = file_get_contents( WC()->plugin_url() . '/assets/images/classic-commerce-dashicon-white-on-transparent.svg' );
-		$cc_icon = base64_encode( $icon_svg );
+		
+		$cc_icon = '';
+		$icon_file = WP_PLUGIN_DIR  . '/classic-commerce/assets/images/classic-commerce-dashicon-white-on-transparent.svg';
+		
+		if ( file_exists( $icon_file ) ) {
+			$icon_svg = file_get_contents( $icon_file );
+			$cc_icon = 'data:image/svg+xml;base64,' . base64_encode( $icon_svg );
+		}
 
 		if ( current_user_can( 'manage_woocommerce' ) ) {
 			$menu[] = array( '', 'read', 'separator-woocommerce', '', 'wp-menu-separator woocommerce' ); // WPCS: override ok.
 		}
 
-		add_menu_page( __( 'Classic Commerce', 'classic-commerce' ), __( 'WooCommerce', 'classic-commerce' ), 'manage_woocommerce', 'woocommerce', null, 'data:image/svg+xml;base64,' . $cc_icon, '55.5' );
+		add_menu_page( __( 'Classic Commerce', 'classic-commerce' ), __( 'WooCommerce', 'classic-commerce' ), 'manage_woocommerce', 'woocommerce', null, $cc_icon, '55.5' );  // A default icon will be used if $cc_icon is empty
 
 		add_submenu_page( 'edit.php?post_type=product', __( 'Attributes', 'classic-commerce' ), __( 'Attributes', 'classic-commerce' ), 'manage_product_terms', 'product_attributes', array( $this, 'attributes_page' ) );
 	}

--- a/includes/admin/class-wc-admin-menus.php
+++ b/includes/admin/class-wc-admin-menus.php
@@ -52,10 +52,10 @@ class WC_Admin_Menus {
 	 */
 	public function admin_menu() {
 		global $menu;
-		
+
 		$cc_icon = '';
-		$icon_file = WP_PLUGIN_DIR  . '/classic-commerce/assets/images/classic-commerce-dashicon-white-on-transparent.svg';
-		
+		$icon_file = WC_ABSPATH . 'assets/images/classic-commerce-dashicon-white-on-transparent.svg';
+
 		if ( file_exists( $icon_file ) ) {
 			$icon_svg = file_get_contents( $icon_file );
 			$cc_icon = 'data:image/svg+xml;base64,' . base64_encode( $icon_svg );
@@ -371,7 +371,7 @@ class WC_Admin_Menus {
 	 * Add the "Visit Store" link in admin bar main menu.
 	 *
 	 * @since WC-2.4.0
-	 * 
+	 *
 	 * @param WP_Admin_Bar $wp_admin_bar Admin bar instance.
 	 */
 	public function admin_bar_menus( $wp_admin_bar ) {

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -21,7 +21,7 @@ final class WooCommerce {
 	 * @var string
 	 */
 	public $version = '3.5.3';
-	public $cc_version = '1.0.0';
+	public $cc_version = '1.0.1';
 
 	/**
 	 * The single instance of the class.


### PR DESCRIPTION
See #288 

Because of SSL certificate issues, using a URL in file_get_contents() can produce errors. Replacing the URL with a file path works around this.