### PR TITLE
Update template override directory

### DIFF
--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -896,10 +896,11 @@ class WC_Email extends WC_Settings_API {
 						continue;
 					}
 
-					$local_file    = $this->get_theme_template_file( $template );
-					$core_file     = $this->template_base . $template;
-					$template_file = apply_filters( 'woocommerce_locate_core_template', $core_file, $template, $this->template_base, $this->id );
-					$template_dir  = apply_filters( 'woocommerce_template_directory', 'classic-commerce', $template );
+					$local_file		= $this->get_theme_template_file( $template );
+					$core_file		= $this->template_base . $template;
+					$template_file	= apply_filters( 'woocommerce_locate_core_template', $core_file, $template, $this->template_base, $this->id );
+					$template_dir	= apply_filters( 'woocommerce_template_directory', 'classic-commerce', $template );
+					$email_docs_url	= 'https://classiccommerce.cc/docs/installation-and-setup/email-settings/';
 					?>
 					<div class="template <?php echo esc_attr( $template_type ); ?>">
 						<h4><?php echo wp_kses_post( $title ); ?></h4>
@@ -956,6 +957,8 @@ class WC_Email extends WC_Settings_API {
 								<?php
 								/* translators: 1: Path to template file 2: Path to theme folder */
 								printf( esc_html__( 'To override and edit this email template copy %1$s to your theme folder: %2$s.', 'classic-commerce' ), '<code>' . esc_html( plugin_basename( $template_file ) ) . '</code>', '<code>' . esc_html( trailingslashit( basename( get_stylesheet_directory() ) ) . $template_dir . '/' . $template ) . '</code>' );
+								/* translators: 1: URL to documentation */
+								printf( __( ' <a href="%1$s" rel="noopener nofollow" target="_blank">View documentation</a>.', 'classic-commerce' ), $email_docs_url ) ;
 								?>
 							</p>
 

--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -741,7 +741,7 @@ class WC_Email extends WC_Settings_API {
 	 * @return string
 	 */
 	public function get_theme_template_file( $template ) {
-		return get_stylesheet_directory() . '/' . apply_filters( 'woocommerce_template_directory', 'woocommerce', $template ) . '/' . $template;
+		return get_stylesheet_directory() . '/' . apply_filters( 'woocommerce_template_directory', 'classic-commerce', $template ) . '/' . $template;
 	}
 
 	/**
@@ -899,7 +899,7 @@ class WC_Email extends WC_Settings_API {
 					$local_file    = $this->get_theme_template_file( $template );
 					$core_file     = $this->template_base . $template;
 					$template_file = apply_filters( 'woocommerce_locate_core_template', $core_file, $template, $this->template_base, $this->id );
-					$template_dir  = apply_filters( 'woocommerce_template_directory', 'woocommerce', $template );
+					$template_dir  = apply_filters( 'woocommerce_template_directory', 'classic-commerce', $template );
 					?>
 					<div class="template <?php echo esc_attr( $template_type ); ?>">
 						<h4><?php echo wp_kses_post( $title ); ?></h4>


### PR DESCRIPTION
See #291

### All Submissions:

* [x] Have you followed the [Classic Commerce Contributing guideline](https://github.com/ClassicPress-plugins/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This is a fix for #291 where the email template override directory was still set to `woocommerce` and not `classic-commerce`.

Closes #291 

Checked and tested on all email templates under Settings -> Emails.

### How to test the changes in this Pull Request:

1. Classic Commerce -> Settings -> Email tab
2. Select any email from list
3. Check text below the template settings. It should say `classic-commerce` instead of `woocommerce`
4. Click on **Copy file to theme** button. 
5. Check theme folder for existence of `classic-commerce/emails` folder. In that folder, there should be a copy of the template you've just copied.
6. Check the text below the email template settings. It should say `This template has been overridden by your theme and can be found in: classicpress-twentyseventeen/classic-commerce/emails/admin-new-order.php` or similar.
7. Repeat for all other email templates.
8. Undo 4. and 7.


### Screenshot - before:

![cc-admin-email-settings](https://user-images.githubusercontent.com/4199514/97862440-42ec0600-1cfd-11eb-8499-b3ca00bd0858.jpg)

### Screenshot - after:

![cc-admin-email-settings-fixed](https://user-images.githubusercontent.com/4199514/97862462-4d0e0480-1cfd-11eb-8f24-80fcba176c55.jpg)
