### PR TITLE
Fix for failing travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,7 @@ before_script:
       echo "xdebug.ini does not exist"
     fi
   - composer install --no-dev
+  - composer self-update 1.8.4
   - |
     # Install WP Test suite, install PHPUnit globally:
     if [[ ! -z "$CP_VERSION" ]]; then


### PR DESCRIPTION
All Travis builds have been failing of late.

Having carried out numerous tests, this seems to be because of an incompatibility with the recently released Composer 2.0. All builds using 2.0 have failed. All builds using 1.8.4 have passed.

This update to `travis.yml` therefore ensures that composer 1.8.4 is used instead of 2.0. 