### PR TITLE
Imported patch for optimizing memory usage

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1357,10 +1357,15 @@ class WC_AJAX {
 			$ids = array_intersect( $ids, (array) $_GET['include'] );
 		}
 
-		$product_objects = array_filter( array_map( 'wc_get_product', $ids ), 'wc_products_array_filter_readable' );
 		$products        = array();
 
-		foreach ( $product_objects as $product_object ) {
+		foreach ( $ids as $id ) {
+			$product_object = wc_get_product( $id );
+			
+			if ( ! wc_products_array_filter_readable( $product_object ) ) {
+				continue;
+			}
+			
 			$formatted_name = $product_object->get_formatted_name();
 			$managing_stock = $product_object->managing_stock();
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Classic Commerce Contributing guideline](https://github.com/ClassicPress-plugins/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

I have imported the following patch to take advantage of this important memory usage improvement in Ajax calls.

https://github.com/woocommerce/woocommerce/pull/28177/