### PR TITLE
Fix for "Undefined offset: 2" in class-wc-plugins-screen-updates.php

### DIFF
--- a/includes/admin/plugin-updates/class-wc-plugins-screen-updates.php
+++ b/includes/admin/plugin-updates/class-wc-plugins-screen-updates.php
@@ -98,13 +98,28 @@ class WC_Plugins_Screen_Updates extends WC_Plugin_Updates {
 	 * @return string
 	 */
 	private function parse_update_notice( $content, $new_version ) {
-		$version_parts     = explode( '.', $new_version );
-		$check_for_notices = array(
-			$version_parts[0] . '.0', // Major.
-			$version_parts[0] . '.0.0', // Major.
-			$version_parts[0] . '.' . $version_parts[1], // Minor.
-			$version_parts[0] . '.' . $version_parts[1] . '.' . $version_parts[2], // Patch.
-		);
+		$version_parts		= explode( '.', $new_version );
+		$check_for_notices	= [];
+
+		if ( isset ( $version_parts[0] ) ) {
+			// Major
+			$check_for_notices = [
+				$version_parts[0] . '.0',
+				$version_parts[0] . '.0.0',
+			];
+			if ( isset ( $version_parts[1] ) ) {
+				// Minor
+				$minor = $version_parts[0] . '.' . $version_parts[1];
+				array_push( $check_for_notices, $minor );
+
+				if ( isset ( $version_parts[2] ) ) {
+					// Patch
+					$patch = $version_parts[0] . '.' . $version_parts[1] . '.' . $version_parts[2];
+					array_push( $check_for_notices, $patch );
+				}
+			}
+		}
+
 		$notice_regexp     = '~==\s*Upgrade Notice\s*==\s*=\s*(.*)\s*=(.*)(=\s*' . preg_quote( $new_version ) . '\s*=|$)~Uis';
 		$upgrade_notice    = '';
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Classic Commerce Contributing guideline](https://github.com/ClassicPress-plugins/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes proposed in this Pull Request:

Fixes PHP notice `"Undefined offset: 2"` in `[...]/classic-commerce/includes/admin/plugin-updates/class-wc-plugins-screen-updates.php` that occurs when an update is available for plugins that do not use Semantic Versioning 3-part (major.minor.patch) version numbers. An example of this is the [CC Compat with WooCommerce](https://github.com/ClassicPress-plugins/cc-compat-woo) which has a version number with the format `9999.x`.

The function `parse_update_notice()` in `class-wc-plugins-screen-updates.php` currently assumes that a 3-part version number is used and, as such, throws the above PHP notice when a plugin uses a 2-part version number.

This error occurs on the plugins page in admin.

This fix adds `isset()` checks for the parts of the version number array.


### How to test the changes in this Pull Request:

**Best done on a staging / non-production site**:

1. Set `define( 'WP_DEBUG', true );` and `define( 'WP_DEBUG_DISPLAY', true);` in `wp-config.php` while also ensuring that `display_errors = On` in `php.ini`.
2. Downgrade the Woo compat plugin to `9999.0`.
3. Go to plugins page in admin & refresh.
4. You should see the following error:
![cc-offset-error](https://user-images.githubusercontent.com/4199514/102692616-649d4000-420c-11eb-8762-cb1d2baa68ba.jpg).
The above error will also be logged in `debug.log` if `define( 'WP_DEBUG_LOG', true );` is also set in `wp-config.php`.
5. Apply the patch in this commit to `class-wc-plugins-screen-updates.php` (after making a backup of the original file first).
6. Delete the transient `_site_transient_update_plugins` in the `wp_options` table in the database (optionally, install a plugin such as [WP-Optimize](https://wordpress.org/plugins/wp-optimize/)).
7. Refresh the plugins page - the error should be gone.

Note that the `_site_transient_update_plugins` transient needs to be deleted before each test / plugins page refresh.

Thanks to @stefanos82 for finding and reporting this on Slack.
