### PR TITLE
Remove WP version check from status report

### DIFF
--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -117,26 +117,7 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 						echo '<mark class="yes"><span class="dashicons dashicons-yes"></span></mark> ' . sprintf( esc_html__( 'You are running ClassicPress Version %s', 'classic-commerce' ), esc_html( $classicpress_version ) );
 					}
 				} else {
-					$latest_version = get_transient( 'woocommerce_system_status_wp_version_check' );
-
-					if ( false === $latest_version ) {
-						$version_check = wp_remote_get( 'https://api.wordpress.org/core/version-check/1.7/' );
-						$api_response  = json_decode( wp_remote_retrieve_body( $version_check ), true );
-
-						if ( $api_response && isset( $api_response['offers'], $api_response['offers'][0], $api_response['offers'][0]['version'] ) ) {
-							$latest_version = $api_response['offers'][0]['version'];
-						} else {
-							$latest_version = $environment['wp_version'];
-						}
-						set_transient( 'woocommerce_system_status_wp_version_check', $latest_version, DAY_IN_SECONDS );
-					}
-
-					if ( version_compare( $environment['wp_version'], $latest_version, '<' ) ) {
-						/* Translators: %1$s: Current version, %2$s: New version */
-						echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( esc_html__( '%1$s - There is a newer version of WordPress available (%2$s)', 'classic-commerce' ), esc_html( $environment['wp_version'] ), esc_html( $latest_version ) ) . '</mark>';
-					} else {
-						echo '<mark class="yes"><span class="dashicons dashicons-yes"></span></mark> ' . sprintf( esc_html__( 'You are running WordPress Version %s', 'classic-commerce' ), esc_html( $environment['wp_version'] ) );
-					}
+						echo sprintf( esc_html__( 'You are running WordPress Version %s', 'classic-commerce' ), esc_html( $environment['wp_version'] ) );
 				}
 				?>
 			</td>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Classic Commerce Contributing guideline](https://github.com/ClassicPress-plugins/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Classic Commerce works perfectly with WP 4.9 ( I haven't tested >5.0) and would be a good e-commerce option for users who have chosen to stay with WP 4.9. Therefore the version check in the status report does not need to nag them to update.
This PR simply shows the current WP version.

Closes #302 .

### How to test the changes in this Pull Request:

1. Copy the one changed file to a test site running WP4.9
2. Check the status report


### Screenshot - before:

![before](https://user-images.githubusercontent.com/46998578/103346602-92299980-4ae8-11eb-98f4-f151063d4860.jpg)

### Screenshot - after:

![after](https://user-images.githubusercontent.com/46998578/103346609-9786e400-4ae8-11eb-83bb-3d976df37810.jpg)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
* [x] Have you included screenshots before/after your changes, if applicable?

<!-- Mark completed items with an [x] -->
