### PR TITLE
Refactor WC_Countries::get_european_union_countries for post-Brexit EU/UK VAT changes

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -372,7 +372,7 @@ class WC_Countries {
 	 * @return array of country codes.
 	 */
 	public function get_vat_countries() {
-		$eu_countries = get_european_union_countries();
+		$eu_countries = $this->get_european_union_countries();
 
 		$countries = array(
 			'GB',

--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -418,7 +418,7 @@ class WC_Countries {
 	 * @return string
 	 */
 	public function tax_or_vat() {
-		$return = in_array( $this->get_base_country(), $this->get_vat_countries(), true ) ? __( 'VAT', 'woocommerce' ) : __( 'Tax', 'woocommerce' );
+		$return = in_array( $this->get_base_country(), $this->get_vat_countries(), true ) ? __( 'VAT', 'classic-commerce' ) : __( 'Tax', 'classic-commerce' );
 
 		return apply_filters( 'woocommerce_countries_tax_or_vat', $return );
 	}
@@ -429,7 +429,7 @@ class WC_Countries {
 	 * @return string
 	 */
 	public function inc_tax_or_vat() {
-		$return = in_array( $this->get_base_country(), $this->get_vat_countries(), true ) ? __( '(incl. VAT)', 'woocommerce' ) : __( '(incl. tax)', 'woocommerce' );
+		$return = in_array( $this->get_base_country(), $this->get_vat_countries(), true ) ? __( '(incl. VAT)', 'classic-commerce' ) : __( '(incl. tax)', 'classic-commerce' );
 
 		return apply_filters( 'woocommerce_countries_inc_tax_or_vat', $return );
 	}
@@ -440,7 +440,7 @@ class WC_Countries {
 	 * @return string
 	 */
 	public function ex_tax_or_vat() {
-		$return = in_array( $this->get_base_country(), $this->get_vat_countries(), true ) ? __( '(ex. VAT)', 'woocommerce' ) : __( '(ex. tax)', 'woocommerce' );
+		$return = in_array( $this->get_base_country(), $this->get_vat_countries(), true ) ? __( '(ex. VAT)', 'classic-commerce' ) : __( '(ex. tax)', 'classic-commerce' );
 
 		return apply_filters( 'woocommerce_countries_ex_tax_or_vat', $return );
 	}

--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -352,20 +352,36 @@ class WC_Countries {
 	/**
 	 * Gets an array of countries in the EU.
 	 *
-	 * MC (monaco) and IM (isle of man, part of UK) also use VAT.
-	 *
-	 * @param  string $type Type of countries to retrieve. Blank for EU member countries. eu_vat for EU VAT countries.
+	 * @param  string $deprecated Function used to return VAT countries based on this.
 	 * @return string[]
 	 */
-	public function get_european_union_countries( $type = '' ) {
+	public function get_european_union_countries( $deprecated = '' ) {
 		$countries = array( 'AT', 'BE', 'BG', 'CY', 'CZ', 'DE', 'DK', 'EE', 'ES', 'FI', 'FR', 'GB', 'GR', 'HU', 'HR', 'IE', 'IT', 'LT', 'LU', 'LV', 'MT', 'NL', 'PL', 'PT', 'RO', 'SE', 'SI', 'SK' );
 
-		if ( 'eu_vat' === $type ) {
-			$countries[] = 'MC';
-			$countries[] = 'IM';
+		if ( ! empty( $deprecated ) ) {
+			wc_deprecated_argument( 'type', '3.9.0', 'Use the WC_Countries::get_vat_countries method instead.' );
+			$countries = get_vat_countries();
 		}
 
-		return apply_filters( 'woocommerce_european_union_countries', $countries, $type );
+		return apply_filters( 'woocommerce_european_union_countries', $countries, $deprecated );
+	}
+
+	/**
+	 * Gets an array of countries using VAT.
+	 *
+	 * @since 3.9.0
+	 * @return array of country codes.
+	 */
+	public function get_vat_countries() {
+		$eu_countries = get_european_union_countries();
+
+		$countries = array(
+			'MC',
+			'IM',
+			'NO',
+		);
+
+		return apply_filters( 'woocommerce_vat_countries', array_merge( $eu_countries, $countries ) );
 	}
 
 	/**
@@ -402,7 +418,7 @@ class WC_Countries {
 	 * @return string
 	 */
 	public function tax_or_vat() {
-		$return = in_array( $this->get_base_country(), array_merge( $this->get_european_union_countries( 'eu_vat' ), array( 'NO' ) ), true ) ? __( 'VAT', 'classic-commerce' ) : __( 'Tax', 'classic-commerce' );
+		$return = in_array( $this->get_base_country(), $this->get_vat_countries(), true ) ? __( 'VAT', 'woocommerce' ) : __( 'Tax', 'woocommerce' );
 
 		return apply_filters( 'woocommerce_countries_tax_or_vat', $return );
 	}
@@ -413,7 +429,7 @@ class WC_Countries {
 	 * @return string
 	 */
 	public function inc_tax_or_vat() {
-		$return = in_array( $this->get_base_country(), array_merge( $this->get_european_union_countries( 'eu_vat' ), array( 'NO' ) ), true ) ? __( '(incl. VAT)', 'classic-commerce' ) : __( '(incl. tax)', 'classic-commerce' );
+		$return = in_array( $this->get_base_country(), $this->get_vat_countries(), true ) ? __( '(incl. VAT)', 'woocommerce' ) : __( '(incl. tax)', 'woocommerce' );
 
 		return apply_filters( 'woocommerce_countries_inc_tax_or_vat', $return );
 	}
@@ -424,7 +440,7 @@ class WC_Countries {
 	 * @return string
 	 */
 	public function ex_tax_or_vat() {
-		$return = in_array( $this->get_base_country(), array_merge( $this->get_european_union_countries( 'eu_vat' ), array( 'NO' ) ), true ) ? __( '(ex. VAT)', 'classic-commerce' ) : __( '(ex. tax)', 'classic-commerce' );
+		$return = in_array( $this->get_base_country(), $this->get_vat_countries(), true ) ? __( '(ex. VAT)', 'woocommerce' ) : __( '(ex. tax)', 'woocommerce' );
 
 		return apply_filters( 'woocommerce_countries_ex_tax_or_vat', $return );
 	}

--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -365,7 +365,7 @@ class WC_Countries {
 			$countries[] = 'IM';
 		}
 
-		return $countries;
+		return apply_filters( 'woocommerce_european_union_countries', $countries, $type );
 	}
 
 	/**

--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -356,7 +356,7 @@ class WC_Countries {
 	 * @return string[]
 	 */
 	public function get_european_union_countries( $deprecated = '' ) {
-		$countries = array( 'AT', 'BE', 'BG', 'CY', 'CZ', 'DE', 'DK', 'EE', 'ES', 'FI', 'FR', 'GB', 'GR', 'HU', 'HR', 'IE', 'IT', 'LT', 'LU', 'LV', 'MT', 'NL', 'PL', 'PT', 'RO', 'SE', 'SI', 'SK' );
+		$countries = array( 'AT', 'BE', 'BG', 'CY', 'CZ', 'DE', 'DK', 'EE', 'ES', 'FI', 'FR', 'GR', 'HU', 'HR', 'IE', 'IT', 'LT', 'LU', 'LV', 'MT', 'NL', 'PL', 'PT', 'RO', 'SE', 'SI', 'SK' );
 
 		if ( ! empty( $deprecated ) ) {
 			wc_deprecated_argument( 'type', '3.9.0', 'Use the WC_Countries::get_vat_countries method instead.' );
@@ -376,8 +376,9 @@ class WC_Countries {
 		$eu_countries = get_european_union_countries();
 
 		$countries = array(
-			'MC',
+			'GB',
 			'IM',
+			'MC',
 			'NO',
 		);
 

--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -352,18 +352,20 @@ class WC_Countries {
 	/**
 	 * Gets an array of countries in the EU.
 	 *
-	 * @param  string $deprecated Function used to return VAT countries based on this.
+	 * @param  string $type Type of countries to retrieve. Blank for EU member countries. eu_vat for EU VAT countries.
 	 * @return string[]
 	 */
-	public function get_european_union_countries( $deprecated = '' ) {
+	public function get_european_union_countries( $type = '' ) {
 		$countries = array( 'AT', 'BE', 'BG', 'CY', 'CZ', 'DE', 'DK', 'EE', 'ES', 'FI', 'FR', 'GR', 'HU', 'HR', 'IE', 'IT', 'LT', 'LU', 'LV', 'MT', 'NL', 'PL', 'PT', 'RO', 'SE', 'SI', 'SK' );
 
-		if ( ! empty( $deprecated ) ) {
-			wc_deprecated_argument( 'type', '3.9.0', 'Use the WC_Countries::get_vat_countries method instead.' );
-			$countries = get_vat_countries();
+		if ( 'eu_vat' === $type ) {
+			$countries[] = 'MC';
+			$countries[] = 'IM';
+			//The UK is still part of the EU VAT zone
+			$countries[] = 'GB';
 		}
 
-		return apply_filters( 'woocommerce_european_union_countries', $countries, $deprecated );
+		return apply_filters( 'woocommerce_european_union_countries', $countries, $type );
 	}
 
 	/**

--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -360,9 +360,6 @@ class WC_Countries {
 
 		if ( 'eu_vat' === $type ) {
 			$countries[] = 'MC';
-			$countries[] = 'IM';
-			//The UK is still part of the EU VAT zone
-			$countries[] = 'GB';
 		}
 
 		return apply_filters( 'woocommerce_european_union_countries', $countries, $type );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Classic Commerce Contributing guideline](https://github.com/ClassicPress-plugins/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Closes #298  .

This is a backport from Woo of all updates relating to EU/UK and IM VAT changes post-[Brexit](https://en.wikipedia.org/wiki/Brexit).

#### Key changes:
1. Remove GB and IM from `$countries` array in `WC_Countries::get_european_union_countries` method
2. Add GB and IM to new `WC_Countries::get_vat_countries` method
3. Add filter to `WC_Countries::get_european_union_countries` method to enable list of countries returned to be customized

#### Woo commits cherry-picked:
- https://github.com/woocommerce/woocommerce/commit/1457de1 - Add filter to the method WC_Countries::get_european_union_countries(). This commit adds a filter called `woocommerce_european_union_countries` to  WC_Countries::get_european_union_countries(). This is to let third party code to customize the list of countries returned by the method.
- https://github.com/woocommerce/woocommerce/commit/34e4869 - Refactor WC_Countries::get_european_union_countries method to exclude VAT handling
- https://github.com/woocommerce/woocommerce/commit/00ade79 - Remove GB from WC_Countries::get_european_union_countries and add them to WC_Countries::get_vat_countries
- https://github.com/woocommerce/woocommerce/commit/80576cb - Revert deprecation of the $type parameter on the get_european_union_countries method
- https://github.com/woocommerce/woocommerce/commit/d523f5a - Merge pull request #28538 from woocommerce/fix/remove-gb-from-eu-vat Remove GB and IM from EU VAT countries


### How to test the changes in this Pull Request:
**(Taken from https://github.com/woocommerce/woocommerce/pull/28538).**
1. Call `WC()->countries->get_european_union_countries()` and `WC()->countries->get_european_union_countries('eu_vat'),` first should exclude GB & IM, second should include it.
2. Apply branch.
3. Both calls should now exclude GB and IM.