### PR TITLE
Fix Undefined index: _low_stock_amount error

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -365,7 +365,7 @@ class WC_Meta_Box_Product_Data {
 				'backorders'         => isset( $_POST['_backorders'] ) ? wc_clean( wp_unslash( $_POST['_backorders'] ) ) : null,
 				'stock_status'       => wc_clean( wp_unslash( $_POST['_stock_status'] ) ),
 				'stock_quantity'     => $stock,
-				'low_stock_amount'   => wc_stock_amount( wp_unslash( $_POST['_low_stock_amount'] ) ),
+				'low_stock_amount'   => isset( $_POST['_low_stock_amount'] ) ? wc_stock_amount( wp_unslash( $_POST['_low_stock_amount'] ) ) : null,
 				'download_limit'     => '' === $_POST['_download_limit'] ? '' : absint( wp_unslash( $_POST['_download_limit'] ) ),
 				'download_expiry'    => '' === $_POST['_download_expiry'] ? '' : absint( wp_unslash( $_POST['_download_expiry'] ) ),
 				'downloads'          => self::prepare_downloads(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Classic Commerce Contributing guideline](https://github.com/ClassicPress-plugins/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When saving a product, the following error is obtained:

`PHP Notice: Undefined index: _low_stock_amount in wp-content/plugins/classic-commerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php on line 368`

The problem is inherited from WooCommerce. It has also been reported on the WordPress site at https://wordpress.org/support/topic/undefined-index-_low_stock_amount-when-saving-product/

WooCommerce issued this fix woocommerce/woocommerce#22681

Closes #312 .

### How to test the changes in this Pull Request:

1. Enable debugging in CP
2. Open any product in admin
3. Save product
4. See error
5. Change the line in the file
6. Open product and save
7. Check no errors 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you included screenshots before/after your changes, if applicable?


