### PR TITLE
Make sale price end on midnight of sale day

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1494,7 +1494,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 				$on_sale = false;
 			}
 
-			if ( $this->get_date_on_sale_to( $context ) && $this->get_date_on_sale_to( $context )->getTimestamp() < current_time( 'timestamp', true ) ) {
+			if ( $this->get_date_on_sale_to( $context ) && $this->get_date_on_sale_to( $context )->getTimestamp() + DAY_IN_SECONDS < current_time( 'timestamp', true ) ) {
 				$on_sale = false;
 			}
 		} else {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Classic Commerce Contributing guideline](https://github.com/ClassicPress-plugins/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The end date for a sale should be midnight on the date set for the sale to end. It currently end at 00:00 on that day ie midnight _of the day before_.

Closes #342 .

### How to test the changes in this Pull Request:

1. Set a product to be on sale ending today (starting today or earlier)
2. Visit the product page
3. The sale price is not shown
4. Make the change to the line in the file 
5. Visit the product page again
6. The sale price now shows

### Screenshot - before:

![before](https://user-images.githubusercontent.com/46998578/134833687-258f314f-8420-4007-bd55-5b3d61f1aac5.jpg)

### Screenshot - after:

![after](https://user-images.githubusercontent.com/46998578/134833694-ae214993-ac1e-4633-8ee6-f782729f99d6.jpg)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
* [x] Have you included screenshots before/after your changes, if applicable?


