### PR TITLE
Fix padding at bottom of email address in emails

### DIFF
--- a/templates/emails/email-addresses.php
+++ b/templates/emails/email-addresses.php
@@ -27,7 +27,7 @@ $text_align = is_rtl() ? 'right' : 'left';
 					<br/><?php echo esc_html( $order->get_billing_phone() ); ?>
 				<?php endif; ?>
 				<?php if ( $order->get_billing_email() ) : ?>
-					<p><?php echo esc_html( $order->get_billing_email() ); ?></p>
+					<br/><?php echo esc_html( $order->get_billing_email() ); ?>
 				<?php endif; ?>
 			</address>
 		</td>

--- a/templates/emails/email-styles.php
+++ b/templates/emails/email-styles.php
@@ -131,7 +131,7 @@ $text_lighter_20 = wc_hex_lighter( $text, 20 );
 }
 
 .address {
-	padding:12px 12px 0;
+	padding:12px;
 	color: <?php echo esc_attr( $text_lighter_20 ); ?>;
 	border: 1px solid <?php echo esc_attr( $body_darker_10 ); ?>;
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Classic Commerce Contributing guideline](https://github.com/ClassicPress-plugins/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

A few small changes to fix the missing padding at the bottom of the shipping address in emails.

The fix was applied in WC 3.5.4
https://github.com/woocommerce/woocommerce/pull/22466

### How to test the changes in this Pull Request:

1. Change the 2 lines in 2 files 
2. Send through a test order
3. See the improved padding

### Screenshot - before:

![before](https://user-images.githubusercontent.com/46998578/134842350-78d49c83-306e-4518-bfb5-f1a55bf1381b.jpg)

### Screenshot - after:

![after](https://user-images.githubusercontent.com/46998578/134842361-24175391-d016-4b89-91d8-1e21c60484c7.jpg)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
* [x] Have you included screenshots before/after your changes, if applicable?

<!-- Mark completed items with an [x] -->
