### PR TITLE
Set low stock threshold to default value

### DIFF
--- a/includes/admin/meta-boxes/views/html-product-data-inventory.php
+++ b/includes/admin/meta-boxes/views/html-product-data-inventory.php
@@ -82,7 +82,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 				'custom_attributes' => array(
 					'step' => 'any',
 				),
-				'data_type'         => 'stock',
 			) );
 
 			do_action( 'woocommerce_product_options_stock_fields' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Classic Commerce Contributing guideline](https://github.com/ClassicPress-plugins/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When enabling stock management at the product level, the value automatically entered as the low stock threshold value is always 0, even though the default value that has been set in the settings area is different eg 2.

This was fixed in WC 3.5.4
https://github.com/woocommerce/woocommerce/pull/22084/files

### How to test the changes in this Pull Request:

1. Enable stock management and leave low stock threshold value at 2
2. Create a new product and enable "manage stock" 
3. Observe the low stock threshold is pre-entered as 0
4. Make the change included in the PR file
5. Create a new product and enable "manage stock"
6. Observe the low stock threshold is pre-entered as 2

### Screenshot - before:

![before](https://user-images.githubusercontent.com/46998578/134845479-3631b657-5fe2-4e74-a432-f9af4be76f63.jpg)

### Screenshot - after:

![after](https://user-images.githubusercontent.com/46998578/134845503-5eefbeaf-5629-4993-b0ad-324bdcab79e5.jpg)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
* [x] Have you included screenshots before/after your changes, if applicable?

