### PR TITLE
Add plugin release Update Manager Client

### DIFF
--- a/classic-commerce.php
+++ b/classic-commerce.php
@@ -143,6 +143,7 @@ if ( $_cc_can_load ) {
 	////////////////////////////////////////////
 
 	// Load the Update Client to manage Classic Commerce updates.
+	include_once dirname( __FILE__ ) . '/includes/class-wc-update-client-config.php';
 	include_once dirname( __FILE__ ) . '/includes/class-wc-update-client.php';
 
 	// Define WC_PLUGIN_FILE.

--- a/includes/class-wc-update-client-config.php
+++ b/includes/class-wc-update-client-config.php
@@ -10,7 +10,7 @@ if (!defined('ABSPATH')) {
 
 class UpdateClientConfig {
 
-	public function __construct( ) {
+	public function __construct() {
 
 		// Deal with privacy options.
 		add_filter( 'codepotent_update_manager_filter_classic-commerce/classic-commerce.php_client_request',	array( $this, 'client_request' ) );
@@ -21,7 +21,7 @@ class UpdateClientConfig {
 
 	}
 
-	public function client_request ( $config ) {
+	public function client_request( $config ) {
 		if ( 'no' === get_option( 'cc_usage_tracking', 'no' ) ) {
 			$config['sfum'] = 'no-log';
 		}
@@ -29,7 +29,7 @@ class UpdateClientConfig {
 	}
 
 	public function patch_paths( $path ) {
-		return preg_replace('/images$/', 'assets/images', $path);
+		return preg_replace( '/images$/', 'assets/images', $path );
 	}
 
 }

--- a/includes/class-wc-update-client-config.php
+++ b/includes/class-wc-update-client-config.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace ClassicCommerce\ClassicCommerce;
+
+// Prevent direct access.
+if (!defined('ABSPATH')) {
+	die();
+}
+
+
+class UpdateClientConfig {
+
+	public function __construct( ) {
+
+		// Deal with privacy options.
+		add_filter( 'codepotent_update_manager_filter_classic-commerce/classic-commerce.php_client_request',	array( $this, 'client_request' ) );
+
+		// Deal with images in a custom location.
+		add_filter( 'codepotent_update_manager_classic-commerce/classic-commerce.php_image_path', 				array( $this, 'patch_paths' ) );
+		add_filter( 'codepotent_update_manager_classic-commerce/classic-commerce.php_image_url' , 				array( $this, 'patch_paths' ) );
+
+	}
+
+	public function client_request ( $config ) {
+		if ( 'no' === get_option( 'cc_usage_tracking', 'no' ) ) {
+			$config['sfum'] = 'no-log';
+		}
+		return $config;
+	}
+
+	public function patch_paths( $path ) {
+		return preg_replace('/images$/', 'assets/images', $path);
+	}
+
+}
+
+new UpdateClientConfig;

--- a/includes/class-wc-update-client.php
+++ b/includes/class-wc-update-client.php
@@ -22,13 +22,12 @@
 namespace ClassicCommerce\ClassicCommerce;
 
 // EDIT: URL where Update Manager is installed; with trailing slash!
-//const UPDATE_SERVER = 'https://officialplugins.classicpress.net/';
-const UPDATE_SERVER = 'https://educatorecinofilo.dog/';
+const UPDATE_SERVER = 'https://classiccommerce.cc/';
 
 // EDIT: Comment this out and fill with the first part of the url
 //       of your Download link to make sure that updates
 //       are served from your trusted source.
-// const SECURE_SOURCE = 'https://github.com/xxsimoxx/codepotent-update-manager/';
+// const SECURE_SOURCE = 'https://github.com/ClassicPress-plugins/classic-commerce';
 
 // EDIT: plugin or theme?
 const UPDATE_TYPE = 'plugin';

--- a/includes/class-wc-update-client.php
+++ b/includes/class-wc-update-client.php
@@ -3,15 +3,18 @@
 /**
  * -----------------------------------------------------------------------------
  * Purpose: Remote client to communicate with the Update Manager plugin.
- * Author: Code Potent
+ * Author: John Alarcon
  * Author URI: https://codepotent.com
+ * API Version: 2.0.0
+ * Last modified on Update Manager release: 2.4.0
  * -----------------------------------------------------------------------------
  * This is free software released under the terms of the General Public License,
  * version 2, or later. It is distributed WITHOUT ANY WARRANTY; without even the
  * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. Full
  * text of the license is available at https://www.gnu.org/licenses/gpl-2.0.txt.
  * -----------------------------------------------------------------------------
- * Copyright 2020, Code Potent
+ * Copyright 2021, John Alarcon (Code Potent)
+ *           2021, Simone Fioravanti
  * -----------------------------------------------------------------------------
  */
 
@@ -19,7 +22,13 @@
 namespace ClassicCommerce\ClassicCommerce;
 
 // EDIT: URL where Update Manager is installed; with trailing slash!
-const UPDATE_SERVER = 'https://officialplugins.classicpress.net/';
+//const UPDATE_SERVER = 'https://officialplugins.classicpress.net/';
+const UPDATE_SERVER = 'https://educatorecinofilo.dog/';
+
+// EDIT: Comment this out and fill with the first part of the url
+//       of your Download link to make sure that updates
+//       are served from your trusted source.
+// const SECURE_SOURCE = 'https://github.com/xxsimoxx/codepotent-update-manager/';
 
 // EDIT: plugin or theme?
 const UPDATE_TYPE = 'plugin';
@@ -49,16 +58,7 @@ class UpdateClient {
 	private $config;
 
 	/**
-	 * Default CP version.
-	 *
-	 * This value is used for comparison in the updates list table by core. This
-	 * property can be set to 4.9.x (whatever x might be at the time,) if you're
-	 * wanting to be exact. The issue with doing that is that you'd have to bump
-	 * that number with every new release of 4.9.x to ensure that core indicates
-	 * 100% compatibility in the table. If your plugin or theme is compatible to
-	 * WordPress 4.9.x, it is compatible with ClassicPress 1.x.x, so, there will
-	 * not be a need for this. Setting it to 4.9.99 ensures don't have to update
-	 * it again.
+	 * Latest CP version.
 	 */
 	private $cp_latest_version = '4.9.99';
 
@@ -96,7 +96,7 @@ class UpdateClient {
 		];
 
 		// Find and store the latest CP version during update process.
-		$this->cp_latest_version = get_option('cp_latest_version', '');
+		$this->cp_latest_version = $this->get_latest_version_number();
 
 		// Hook the update client into the system.
 		$this->init();
@@ -227,14 +227,17 @@ class UpdateClient {
 		// Is there a response?
 		if (isset($value->response)) {
 
-			// Ensure the latest ClassicPress version number is available.
-			$this->get_latest_version_number();
-
 			// Get the installed components.
 			$components = $this->get_component_data('query_'.$this->config['type'].'s');
 
 			// Iterate over installed components.
 			foreach($components as $component=>$data) {
+
+				// If necessary check if the new package come from the right source.
+				if (defined(__NAMESPACE__.'\SECURE_SOURCE') && isset($data['package']) && strpos($data['package'], SECURE_SOURCE) !== 0) {
+					unset($value->response[$component]);
+					continue;
+				}
 
 				// Is there a new version?
 				if (isset($data['id'], $data['new_version'], $data['package'])) {
@@ -327,6 +330,11 @@ class UpdateClient {
 		// Get the component's information.
 		$info = $this->get_component_data($action, $list_components[$args->slug]);
 
+		// If the request failed, pass through an informative error message.
+		if (is_wp_error($info)) {
+			return $info;
+		}
+
 		// If the response has all the right properties, cast $info to object.
 		if (isset($info['name'], $info['slug'], $info['external'], $info['sections'])) {
 			$res = (object)$info;
@@ -375,7 +383,7 @@ class UpdateClient {
 			$anchors_string = implode('', $component_meta);
 			$anchor_text = esc_html__('View details');
 			if (!preg_match('|(\<a[ \s\S\d]*)('.$anchor_text.')(<\/a>)|', $anchors_string)) {
-				$component_meta[] = '<a class="thickbox" href="'.admin_url('/'.$this->config['type'].'-install.php?tab='.$this->config['type'].'-information&'.$this->config['type'].'='.$this->server_slug.'&TB_iframe=true&width=600&height=550').'">'.$anchor_text.'</a>';
+				$component_meta[] = '<a class="thickbox open-plugin-details-modal" href="'.admin_url('/'.$this->config['type'].'-install.php?tab='.$this->config['type'].'-information&'.$this->config['type'].'='.$this->server_slug.'&TB_iframe=true&width=600&height=550').'">'.$anchor_text.'</a>';
 			}
 		}
 
@@ -566,7 +574,7 @@ class UpdateClient {
 		global $cp_version;
 
 		// Initialize the data to be posted.
-		$body = $this->config['post'];
+		$body = apply_filters('codepotent_update_manager_filter_'.$this->config['id'].'_client_request', $this->config['post']);
 
 		if ($action === 'plugin_information') {
 
@@ -651,12 +659,21 @@ class UpdateClient {
 		}
 
 		// Still an error? Hey, you tried. Bail.
-		if (is_wp_error($raw_response) || 200 != wp_remote_retrieve_response_code($raw_response)) {
-			return [];
+		if (is_wp_error($raw_response)) {
+			return new \WP_Error('update_manager_http_error', __('HTTP error.') . ' ' . $raw_response->get_error_message(), ['original_error' => $raw_response]);
+		}
+		$response_code = wp_remote_retrieve_response_code($raw_response);
+		if (200 != $response_code) {
+			return new \WP_Error('update_manager_http_error', __('HTTP error.') . ' ' . $response_code, compact('raw_response'));
 		}
 
 		// Get the response body; decode it as an array.
 		$data = json_decode(trim(wp_remote_retrieve_body($raw_response)), true);
+
+		// If decoding fails, bail.
+		if ($data === null) {
+			return new \WP_Error('update_manager_http_error', __('Invalid API response (invalid JSON)'), $raw_response);
+		}
 
 		// Set retrieved data to the object for reuse elsewhere.
 		$this->component_data = is_array($data) ? $data : [];
@@ -713,12 +730,16 @@ class UpdateClient {
 		}
 
 		// Set path and URL to this plugin's own images directory.
-		$image_path = untrailingslashit(WP_PLUGIN_DIR).'/'.$plugin.'/assets/images';
-		$image_url  = untrailingslashit(WP_PLUGIN_URL).'/'.$plugin.'/assets/images';
+		$image_path = untrailingslashit(WP_PLUGIN_DIR).'/'.$plugin.'/images';
+		$image_url  = untrailingslashit(WP_PLUGIN_URL).'/'.$plugin.'/images';
 
-		// Allow directory location to be filtered.
+		// Allow directory location to be filtered. DEPRECATED FILTERS.
 		$image_path = apply_filters('codepotent_update_manager_image_path', $image_path);
 		$image_url  = apply_filters('codepotent_update_manager_image_url', $image_url);
+
+		// Allow directory location to be filtered. NEW FILTERS.
+		$image_path = apply_filters('codepotent_update_manager_'.$this->config['id'].'_image_path', $image_path);
+		$image_url  = apply_filters('codepotent_update_manager_'.$this->config['id'].'_image_url', $image_url);
 
 		// Banner and icon images are keyed differently; it's a core thing.
 		$image_qualities = [
@@ -814,7 +835,7 @@ class UpdateClient {
 		$version = get_transient('codepotent_update_manager_cp_version');
 
 		// Return version number, if now known.
-		if (!empty($version)) {
+		if (false !== $version) {
 			return $version;
 		}
 
@@ -848,8 +869,9 @@ class UpdateClient {
 			$version = str_replace('.json', '', $version);
 		}
 
-		// A transient ensures the query is not run more than every 10 minutes.
-		set_transient('codepotent_update_manager_cp_version', $version, MINUTE_IN_SECONDS * 10);
+		// A transient ensures the query is not run more than every 6 hours.
+		set_transient('codepotent_update_manager_cp_version', $version, HOUR_IN_SECONDS * 6);
+		update_option('cp_latest_version', $version);
 
 		// Return the version string.
 		return $version;


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Classic Commerce Contributing guideline](https://github.com/ClassicPress-plugins/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

1. Update the Update client to latest version (Last modified on Update Manager release: 2.4.0).
2. Added filters that points to the right location of images.
3. Added filter to handle plugin usage statistics privacy opt-out.

Closes #211 .

Maybe (that is not already added) we should limit the download of a new version from this repo?

