### PR TITLE
Add min WC version check to status report

### DIFF
--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -551,7 +551,7 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 				<?php if ( $security['hide_errors'] ) : ?>
 					<mark class="yes"><span class="dashicons dashicons-yes"></span></mark>
 				<?php else : ?>
-					<mark class="error"><span class="dashicons dashicons-warning"></span><?php esc_html_e( 'Error messages should not be shown to visitors.', 'classic-commerce' ); ?></mark>
+					<mark class="error"><span class="dashicons dashicons-warning"></span> <?php esc_html_e( 'Error messages should not be shown to visitors.', 'classic-commerce' ); ?></mark>
 				<?php endif; ?>
 			</td>
 		</tr>
@@ -566,6 +566,13 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 	<tbody>
 		<?php
 		foreach ( $active_plugins as $plugin ) {
+
+			$plugin_path = WP_PLUGIN_DIR . '/' . $plugin['plugin'];
+
+			$plugin_details = get_file_data( $plugin_path, array(
+						'WC requires at least' => 'WC requires at least'
+					) );
+
 			if ( ! empty( $plugin['name'] ) ) {
 				$dirname = dirname( $plugin['plugin'] );
 
@@ -591,6 +598,13 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 				if ( array_key_exists( $plugin['plugin'], $untested_plugins ) ) {
 					$untested_string = ' &ndash; <strong style="color:red;">' . esc_html__( 'Not tested with the active version of Classic Commerce', 'classic-commerce' ) . '</strong>';
 				}
+				$WC_requires = '';
+				if ( $plugin_details['WC requires at least'] !== '' ) {
+					$WC_requires = ' &ndash; ' . esc_html__( 'Requires at least WC ' . $plugin_details['WC requires at least'], 'classic-commerce' );
+					if (version_compare($plugin_details['WC requires at least'], '3.5.3', '>')) {
+						$WC_requires = ' &ndash; <mark class="error"><span class="dashicons dashicons-warning"></span> ' . esc_html__( 'Requires at least WC ', 'classic-commerce' ) . $plugin_details['WC requires at least'] . '</mark>';
+					}
+				}
 				?>
 				<tr>
 					<td><?php echo wp_kses_post( $plugin_name ); ?></td>
@@ -599,7 +613,7 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 					<?php
 						/* translators: %s: plugin author */
 						printf( esc_html__( 'by %s', 'classic-commerce' ), esc_html( $plugin['author_name'] ) );
-						echo ' &ndash; ' . esc_html( $plugin['version'] ) . $version_string . $untested_string . $network_string; // WPCS: XSS ok.
+						echo ' &ndash; ' . esc_html( $plugin['version'] ) . $version_string . $untested_string . $network_string . $WC_requires; // WPCS: XSS ok.
 					?>
 					</td>
 				</tr>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Classic Commerce Contributing guideline](https://github.com/ClassicPress-plugins/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Add a check on any "WC requires at least tag" that can be found in active plugins and display on the status report. Flag possible incompatible plugins in red.

Closes #336.

### How to test the changes in this Pull Request:

1. Copy in the changed file to a test site (make sure you have a good range of WC plugins active)
2. Run the status report
3. Check the active plugin list and see the added info at the end of the line. 
4. WC plugins requiring > 3.5.3 should be flagged in red

### Screenshot - before:

![before](https://user-images.githubusercontent.com/46998578/135700415-71d2ed82-185c-40c1-91ee-48292a02c4e0.jpg)

### Screenshot - after:

![after](https://user-images.githubusercontent.com/46998578/135700418-3c22ecb4-7de0-4b3e-b580-c27b7e77e000.jpg)

### Other information:

Code probably needs tidying up. 

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
* [x] Have you included screenshots before/after your changes, if applicable?


